### PR TITLE
Use pointer-safe window handles in max2w3d

### DIFF
--- a/Generals/Code/Tools/WW3D/max2w3d/FormClass.cpp
+++ b/Generals/Code/Tools/WW3D/max2w3d/FormClass.cpp
@@ -78,9 +78,10 @@ FormClass::Create_Form
 	assert(m_hWnd);
 
 	// Remove the caption from the dialog (if there was any)
-	::SetWindowLong (m_hWnd,
-						  GWL_STYLE,
-						  ::GetWindowLong (m_hWnd, GWL_STYLE) & (~WS_CAPTION));
+        const LONG_PTR style = ::GetWindowLongPtr(m_hWnd, GWL_STYLE);
+        ::SetWindowLongPtr(m_hWnd,
+                                                  GWL_STYLE,
+                                                  style & (~static_cast<LONG_PTR>(WS_CAPTION)));
 
 	::GetWindowRect (m_hWnd, &m_FormRect);
 

--- a/Generals/Code/Tools/WW3D/max2w3d/GameMtlDlg.cpp
+++ b/Generals/Code/Tools/WW3D/max2w3d/GameMtlDlg.cpp
@@ -494,12 +494,12 @@ static BOOL CALLBACK DisplacementMapDlgProc(HWND hwndDlg, UINT msg, WPARAM wPara
 	if (msg == WM_INITDIALOG) {
 		theDlg = (GameMtlDlg*)lParam;
 		theDlg->HwndDisplacementMap = hwndDlg;
-		SetWindowLong(hwndDlg, GWL_USERDATA,lParam);
-	} else {
-		if ((theDlg = (GameMtlDlg *)GetWindowLong(hwndDlg, GWL_USERDATA) ) == NULL) {
-			return FALSE; 
-		}
-	}
+                SetWindowLongPtr(hwndDlg, GWLP_USERDATA, static_cast<LONG_PTR>(lParam));
+        } else {
+                if ((theDlg = reinterpret_cast<GameMtlDlg *>(GetWindowLongPtr(hwndDlg, GWLP_USERDATA))) == NULL) {
+                        return FALSE;
+                }
+        }
 
 	theDlg->IsActive = 1;
 	BOOL res = theDlg->DisplacementMapProc(hwndDlg,msg,wParam,lParam);
@@ -514,12 +514,12 @@ static BOOL CALLBACK SurfaceTypePanelDlgProc(HWND hwndDlg, UINT msg, WPARAM wPar
 	if (msg == WM_INITDIALOG) {
 		theDlg = (GameMtlDlg*)lParam;
 		theDlg->HwndSurfaceType = hwndDlg;
-		SetWindowLong(hwndDlg, GWL_USERDATA,lParam);
-	} else {
-		if ((theDlg = (GameMtlDlg *)GetWindowLong(hwndDlg, GWL_USERDATA) ) == NULL) {
-			return FALSE; 
-		}
-	}
+                SetWindowLongPtr(hwndDlg, GWLP_USERDATA, static_cast<LONG_PTR>(lParam));
+        } else {
+                if ((theDlg = reinterpret_cast<GameMtlDlg *>(GetWindowLongPtr(hwndDlg, GWLP_USERDATA))) == NULL) {
+                        return FALSE;
+                }
+        }
 
 	theDlg->IsActive = 1;
 	BOOL res = theDlg->SurfaceTypeProc(hwndDlg,msg,wParam,lParam);
@@ -534,12 +534,12 @@ static BOOL CALLBACK PassCountPanelDlgProc(HWND hwndDlg, UINT msg, WPARAM wParam
 	if (msg == WM_INITDIALOG) {
 		theDlg = (GameMtlDlg*)lParam;
 		theDlg->HwndPassCount = hwndDlg;
-		SetWindowLong(hwndDlg, GWL_USERDATA,lParam);
-	} else {
-		if ((theDlg = (GameMtlDlg *)GetWindowLong(hwndDlg, GWL_USERDATA) ) == NULL) {
-			return FALSE; 
-		}
-	}
+                SetWindowLongPtr(hwndDlg, GWLP_USERDATA, static_cast<LONG_PTR>(lParam));
+        } else {
+                if ((theDlg = reinterpret_cast<GameMtlDlg *>(GetWindowLongPtr(hwndDlg, GWLP_USERDATA))) == NULL) {
+                        return FALSE;
+                }
+        }
 
 	theDlg->IsActive = 1;
 	BOOL res = theDlg->PassCountProc(hwndDlg,msg,wParam,lParam);

--- a/Generals/Code/Tools/WW3D/max2w3d/GameMtlPassDlg.cpp
+++ b/Generals/Code/Tools/WW3D/max2w3d/GameMtlPassDlg.cpp
@@ -85,12 +85,12 @@ static BOOL CALLBACK PassDlgProc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM l
 	if (msg==WM_INITDIALOG) {
 		theDlg = (GameMtlPassDlg*)lParam;
 		theDlg->HwndPanel = hwndDlg;
-		SetWindowLong(hwndDlg, GWL_USERDATA,lParam);
-	} else {
-		if ((theDlg = (GameMtlPassDlg *)GetWindowLong(hwndDlg, GWL_USERDATA) ) == NULL) {
-			return FALSE; 
-		}
-	}
+                SetWindowLongPtr(hwndDlg, GWLP_USERDATA, static_cast<LONG_PTR>(lParam));
+        } else {
+                if ((theDlg = reinterpret_cast<GameMtlPassDlg *>(GetWindowLongPtr(hwndDlg, GWLP_USERDATA))) == NULL) {
+                        return FALSE;
+                }
+        }
 
 	return theDlg->DialogProc(hwndDlg,msg,wParam,lParam);
 }
@@ -145,7 +145,7 @@ GameMtlPassDlg::~GameMtlPassDlg()
 {
 	TheMtl->Set_Flag(_Pass_Index_To_Flag[PassIndex],IParams->IsRollupPanelOpen(HwndPanel));
 	IParams->DeleteRollupPage(HwndPanel);
-	SetWindowLong(HwndPanel, GWL_USERDATA, NULL);
+        SetWindowLongPtr(HwndPanel, GWLP_USERDATA, 0);
 }
 
 

--- a/Generals/Code/Tools/WW3D/max2w3d/dllmain.h
+++ b/Generals/Code/Tools/WW3D/max2w3d/dllmain.h
@@ -41,6 +41,36 @@
 
 #include <windows.h>
 
+#ifndef GWLP_WNDPROC
+#define GWLP_WNDPROC GWL_WNDPROC
+#endif
+
+#ifndef GWLP_USERDATA
+#define GWLP_USERDATA GWL_USERDATA
+#endif
+
+#ifndef GetWindowLongPtr
+#ifdef _WIN64
+#error "GetWindowLongPtr must be available on 64-bit targets."
+#else
+inline LONG_PTR GetWindowLongPtr(HWND hWnd, int nIndex)
+{
+        return static_cast<LONG_PTR>(::GetWindowLong(hWnd, nIndex));
+}
+#endif
+#endif
+
+#ifndef SetWindowLongPtr
+#ifdef _WIN64
+#error "SetWindowLongPtr must be available on 64-bit targets."
+#else
+inline LONG_PTR SetWindowLongPtr(HWND hWnd, int nIndex, LONG_PTR dwNewLong)
+{
+        return static_cast<LONG_PTR>(::SetWindowLong(hWnd, nIndex, static_cast<LONG>(dwNewLong)));
+}
+#endif
+#endif
+
 extern HINSTANCE AppInstance;
 
 #define MAX_STRING_LENGTH 256

--- a/Generals/Code/Tools/WW3D/max2w3d/floaterdialog.cpp
+++ b/Generals/Code/Tools/WW3D/max2w3d/floaterdialog.cpp
@@ -206,7 +206,7 @@ bool FloaterDialogClass::Dialog_Proc(HWND hWnd,UINT message,WPARAM wParam,LPARAM
 												);
 				if (childhwnd!= NULL) {
 					RECT rect;
-					LONG style = ::GetWindowLong(hWnd,GWL_STYLE);
+                                        const DWORD style = static_cast<DWORD>(::GetWindowLongPtr(hWnd, GWL_STYLE));
 					::GetWindowRect(childhwnd,&rect);
 					::AdjustWindowRect(&rect,style,FALSE);
 					::SetWindowPos(hWnd,NULL,0,0,rect.right - rect.left,rect.bottom - rect.top,SWP_NOZORDER|SWP_NOMOVE);

--- a/Generals/Code/Tools/WW3D/max2w3d/gmtldlg.cpp
+++ b/Generals/Code/Tools/WW3D/max2w3d/gmtldlg.cpp
@@ -351,12 +351,12 @@ BOOL GameMtlDlg::PanelProc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam 
 				SendDlgItemMessage( hwndDlg, IDC_SIT_MAPPING_COMBO, CB_ADDSTRING, 0, (LPARAM) (LPCTSTR) Get_String(IDS_UV_MAPPING));
 				SendDlgItemMessage( hwndDlg, IDC_SIT_MAPPING_COMBO, CB_ADDSTRING, 0, (LPARAM) (LPCTSTR) Get_String(IDS_ENVIRONMENT_MAPPING) );
 
-				/* Installing a windproc for texmap buttons which will handle drag-n-drop
-				HWND hw = GetDlgItem(hwndDlg, texMapID[i]);
-				WNDPROC oldp = (WNDPROC)GetWindowLong(hw, GWL_WNDPROC);
-				SetWindowLong( hw, GWL_WNDPROC, (LONG)TexSlotWndProc);
-				SetWindowLong( hw, GWL_USERDATA, (LONG)oldp);
-				*/
+                                /* Installing a windproc for texmap buttons which will handle drag-n-drop
+                                HWND hw = GetDlgItem(hwndDlg, texMapID[i]);
+                                WNDPROC oldp = reinterpret_cast<WNDPROC>(GetWindowLongPtr(hw, GWLP_WNDPROC));
+                                SetWindowLongPtr(hw, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(TexSlotWndProc));
+                                SetWindowLongPtr(hw, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(oldp));
+                                */
 
 				return TRUE;
 			}
@@ -621,9 +621,9 @@ static BOOL CALLBACK PanelDlgProc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM 
 	if (msg==WM_INITDIALOG) {
 		theDlg = (GameMtlDlg*)lParam;
 		theDlg->HwndPanel = hwndDlg;
-		SetWindowLong(hwndDlg, GWL_USERDATA,lParam);
-	} else {
-		if ((theDlg = (GameMtlDlg *)GetWindowLong(hwndDlg, GWL_USERDATA) ) == NULL) {
+                SetWindowLongPtr(hwndDlg, GWLP_USERDATA, static_cast<LONG_PTR>(lParam));
+        } else {
+                if ((theDlg = reinterpret_cast<GameMtlDlg *>(GetWindowLongPtr(hwndDlg, GWLP_USERDATA))) == NULL) {
 			return FALSE; 
 		}
 	}
@@ -692,9 +692,9 @@ static BOOL CALLBACK NotesDlgProc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM 
 	if (msg==WM_INITDIALOG) {
 		theDlg = (GameMtlDlg*)lParam;
 		theDlg->HwndNotes = hwndDlg;
-		SetWindowLong(hwndDlg, GWL_USERDATA,lParam);
-	} else {
-		if ((theDlg = (GameMtlDlg *)GetWindowLong(hwndDlg, GWL_USERDATA) ) == NULL) {
+                SetWindowLongPtr(hwndDlg, GWLP_USERDATA, static_cast<LONG_PTR>(lParam));
+        } else {
+                if ((theDlg = reinterpret_cast<GameMtlDlg *>(GetWindowLongPtr(hwndDlg, GWLP_USERDATA))) == NULL) {
 			return FALSE; 
 		}
 	}
@@ -785,9 +785,9 @@ static BOOL CALLBACK HintsDlgProc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM 
 	if (msg==WM_INITDIALOG) {
 		theDlg = (GameMtlDlg*)lParam;
 		theDlg->HwndHints = hwndDlg;
-		SetWindowLong(hwndDlg, GWL_USERDATA,lParam);
-	} else {
-		if ((theDlg = (GameMtlDlg *)GetWindowLong(hwndDlg, GWL_USERDATA) ) == NULL) {
+                SetWindowLongPtr(hwndDlg, GWLP_USERDATA, static_cast<LONG_PTR>(lParam));
+        } else {
+                if ((theDlg = reinterpret_cast<GameMtlDlg *>(GetWindowLongPtr(hwndDlg, GWLP_USERDATA))) == NULL) {
 			return FALSE; 
 		}
 	}
@@ -879,13 +879,13 @@ static BOOL CALLBACK PsxDlgProc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lP
 	GameMtlDlg *theDlg;
 
 	if (msg==WM_INITDIALOG) {
-		theDlg = (GameMtlDlg*)lParam;
-		theDlg->HwndPsx = hwndDlg;
-		SetWindowLong(hwndDlg, GWL_USERDATA,lParam);
-	} else {
-		if ((theDlg = (GameMtlDlg *)GetWindowLong(hwndDlg, GWL_USERDATA) ) == NULL) {
-			return FALSE; 
-		}
+                theDlg = (GameMtlDlg*)lParam;
+                theDlg->HwndPsx = hwndDlg;
+                SetWindowLongPtr(hwndDlg, GWLP_USERDATA, static_cast<LONG_PTR>(lParam));
+        } else {
+                if ((theDlg = reinterpret_cast<GameMtlDlg *>(GetWindowLongPtr(hwndDlg, GWLP_USERDATA))) == NULL) {
+                        return FALSE;
+                }
 	}
 
 	BOOL res;

--- a/Generals/Code/Tools/WW3D/max2w3d/skin.cpp
+++ b/Generals/Code/Tools/WW3D/max2w3d/skin.cpp
@@ -194,8 +194,8 @@ void SkinWSMObjectClass::BeginEditParams(IObjParam  *ip, ULONG flags,Animatable 
 					Get_String(IDS_SOT), 
 					(LPARAM)InterfacePtr,
 					APPENDROLL_CLOSED);
-	} else {
-		SetWindowLong(SotHWND,GWL_USERDATA,(LPARAM)ip);
+        } else {
+                SetWindowLongPtr(SotHWND,GWLP_USERDATA,reinterpret_cast<LONG_PTR>(ip));
 	}
 
 	/*
@@ -209,8 +209,8 @@ void SkinWSMObjectClass::BeginEditParams(IObjParam  *ip, ULONG flags,Animatable 
 					Get_String(IDS_SKELETON_PARAMETERS), 
 					(LPARAM)this,
 					0);
-	} else {
-		SetWindowLong(SkeletonHWND,GWL_USERDATA,(LPARAM)this);
+        } else {
+                SetWindowLongPtr(SkeletonHWND,GWLP_USERDATA,reinterpret_cast<LONG_PTR>(this));
 	}
 
 	Update_Bone_List();
@@ -1617,12 +1617,12 @@ void SkinModifierClass::Remove_Bone_Influence_Dialog(void)
 *********************************************************************************/
 static BOOL CALLBACK _sot_dialog_proc(HWND hWnd,UINT message,WPARAM wParam,LPARAM lParam)
 {
-	IObjParam *ip = (IObjParam*)GetWindowLong(hWnd,GWL_USERDATA);
+        IObjParam *ip = reinterpret_cast<IObjParam *>(GetWindowLongPtr(hWnd,GWLP_USERDATA));
 
 	switch (message) {
-		case WM_INITDIALOG:
-			SetWindowLong(hWnd,GWL_USERDATA,lParam);
-			break;
+                case WM_INITDIALOG:
+                        SetWindowLongPtr(hWnd,GWLP_USERDATA,static_cast<LONG_PTR>(lParam));
+                        break;
 
 		case WM_LBUTTONDOWN:
 		case WM_LBUTTONUP:
@@ -1644,13 +1644,13 @@ static BOOL CALLBACK _sot_dialog_proc(HWND hWnd,UINT message,WPARAM wParam,LPARA
 *********************************************************************************/
 static BOOL CALLBACK _skeleton_dialog_thunk(HWND hWnd,UINT message,WPARAM wParam,LPARAM lParam)
 {
-	SkinWSMObjectClass * skinobj = (SkinWSMObjectClass *)GetWindowLong(hWnd,GWL_USERDATA);
-	if (!skinobj && message != WM_INITDIALOG) return FALSE;
-	
-	if (message == WM_INITDIALOG) {
-		skinobj = (SkinWSMObjectClass *)lParam;
-		SetWindowLong(hWnd,GWL_USERDATA,(LONG)skinobj);			
-	}
+        SkinWSMObjectClass * skinobj = reinterpret_cast<SkinWSMObjectClass *>(GetWindowLongPtr(hWnd,GWLP_USERDATA));
+        if (!skinobj && message != WM_INITDIALOG) return FALSE;
+
+        if (message == WM_INITDIALOG) {
+                skinobj = reinterpret_cast<SkinWSMObjectClass *>(lParam);
+                SetWindowLongPtr(hWnd,GWLP_USERDATA,reinterpret_cast<LONG_PTR>(skinobj));
+        }
 
 	return skinobj->Skeleton_Dialog_Proc(hWnd,message,wParam,lParam);
 }
@@ -1753,13 +1753,13 @@ BOOL SkinWSMObjectClass::Skeleton_Dialog_Proc(HWND hWnd,UINT message,WPARAM wPar
 *********************************************************************************/
 static BOOL CALLBACK _bone_influence_dialog_thunk(HWND hWnd,UINT message,WPARAM wParam,LPARAM lParam)
 {
-	SkinModifierClass * skinmod = (SkinModifierClass *)GetWindowLong(hWnd,GWL_USERDATA);
-	if (!skinmod && message != WM_INITDIALOG) return FALSE;
-	
-	if (message == WM_INITDIALOG) {
-			skinmod = (SkinModifierClass *)lParam;
-			SetWindowLong(hWnd,GWL_USERDATA,(LONG)skinmod);			
-	}
+        SkinModifierClass * skinmod = reinterpret_cast<SkinModifierClass *>(GetWindowLongPtr(hWnd,GWLP_USERDATA));
+        if (!skinmod && message != WM_INITDIALOG) return FALSE;
+
+        if (message == WM_INITDIALOG) {
+                        skinmod = reinterpret_cast<SkinModifierClass *>(lParam);
+                        SetWindowLongPtr(hWnd,GWLP_USERDATA,reinterpret_cast<LONG_PTR>(skinmod));
+        }
 
 	return skinmod->Bone_Influence_Dialog_Proc(hWnd,message,wParam,lParam);
 }


### PR DESCRIPTION
## Summary
- replace legacy Get/SetWindowLong usages in the max2w3d plug-in dialogs with Get/SetWindowLongPtr and the GWLP_* indexes
- add compatibility helpers so the plug-in continues to build against 32-bit SDKs while supporting pointer-sized window data on 64-bit Max

## Testing
- Not run (3ds Max build environment is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68ca810a5b788331aa4ddff17a543d2c