### PR TITLE
Integrate SFML bootstrap with game startup

### DIFF
--- a/Generals/Code/Main/ApplicationGlobals.cpp
+++ b/Generals/Code/Main/ApplicationGlobals.cpp
@@ -1,0 +1,33 @@
+/*
+**      Command & Conquer Generals(tm)
+**      Copyright 2025 Electronic Arts Inc.
+**
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
+**
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
+**
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "WinMain.h"
+#include "Lib/BaseType.h"
+
+HINSTANCE ApplicationHInstance = NULL;
+HWND ApplicationHWnd = NULL;
+HDC ApplicationHDC = NULL;
+HGLRC ApplicationHGLRC = NULL;
+Bool ApplicationIsWindowed = false;
+GraphicsBackend ApplicationGraphicsBackend = GRAPHICS_BACKEND_DIRECT3D8;
+Win32Mouse* TheWin32Mouse = NULL;
+DWORD TheMessageTime = 0;
+
+const Char* g_strFile = "data\\Generals.str";
+const Char* g_csfFile = "data\\%s\\Generals.csf";
+char* gAppPrefix = "";

--- a/Generals/Code/Main/GameEngineFactory.cpp
+++ b/Generals/Code/Main/GameEngineFactory.cpp
@@ -1,0 +1,31 @@
+/*
+**      Command & Conquer Generals(tm)
+**      Copyright 2025 Electronic Arts Inc.
+**
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
+**
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
+**
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "WinMain.h"
+#include "Common/GameEngine.h"
+#include "Common/GameMemory.h"
+#include "Win32Device/Common/Win32GameEngine.h"
+
+Bool gInitialEngineActiveState = true;
+
+GameEngine* CreateGameEngine(void)
+{
+        Win32GameEngine* engine = NEW Win32GameEngine;
+        engine->setIsActive(gInitialEngineActiveState);
+        return engine;
+}

--- a/Generals/Code/Main/WinMain.cpp
+++ b/Generals/Code/Main/WinMain.cpp
@@ -76,20 +76,6 @@
 //#pragma message("************************************** WARNING, optimization disabled for debugging purposes")
 #endif
 
-// GLOBALS ////////////////////////////////////////////////////////////////////
-HINSTANCE ApplicationHInstance = NULL;  ///< our application instance
-HWND ApplicationHWnd = NULL;  ///< our application window handle
-HDC ApplicationHDC = NULL;  ///< device context for OpenGL rendering
-HGLRC ApplicationHGLRC = NULL; ///< OpenGL rendering context
-Bool ApplicationIsWindowed = false;
-GraphicsBackend ApplicationGraphicsBackend = GRAPHICS_BACKEND_DIRECT3D8;
-Win32Mouse *TheWin32Mouse= NULL;  ///< for the WndProc() only
-DWORD TheMessageTime = 0;	///< For getting the time that a message was posted from Windows.
-
-const Char *g_strFile = "data\\Generals.str";
-const Char *g_csfFile = "data\\%s\\Generals.csf";
-char *gAppPrefix = ""; /// So WB can have a different debug log file name.
-
 static HANDLE GeneralsMutex = NULL;
 #define GENERALS_GUID "685EAFF2-3216-4265-B047-251C5F4B82F3"
 #define DEFAULT_XRESOLUTION 800
@@ -1211,10 +1197,12 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 		}
 #endif
 
-		DEBUG_LOG(("CRC message is %d\n", GameMessage::MSG_LOGIC_CRC));
+                DEBUG_LOG(("CRC message is %d\n", GameMessage::MSG_LOGIC_CRC));
 
-		// run the game main loop
-		GameMain(argc, argv);
+                gInitialEngineActiveState = isWinMainActive;
+
+                // run the game main loop
+                GameMain(argc, argv);
 
 #ifdef DO_COPY_PROTECTION
 		// Clean up copy protection
@@ -1253,19 +1241,3 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 	return 0;
 
 }  // end WinMain
-
-// CreateGameEngine ===========================================================
-/** Create the Win32 game engine we're going to use */
-//=============================================================================
-GameEngine *CreateGameEngine( void )
-{
-	Win32GameEngine *engine;
-
-	engine = NEW Win32GameEngine;
-	//game engine may not have existed when app got focus so make sure it
-	//knows about current focus state.
-	engine->setIsActive(isWinMainActive);
-
-	return engine;
-
-}  // end CreateGameEngine

--- a/Generals/Code/Main/WinMain.h
+++ b/Generals/Code/Main/WinMain.h
@@ -53,6 +53,12 @@ enum GraphicsBackend
 
 extern GraphicsBackend ApplicationGraphicsBackend; ///< active rendering backend
 extern Win32Mouse *TheWin32Mouse;  ///< global for win32 mouse only!
+extern DWORD TheMessageTime;       ///< For getting the time that a message was posted from Windows.
+extern Bool gInitialEngineActiveState;
+
+#ifdef _WIN32
+LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
+#endif
 
 #endif  // end __WINMAIN_H_
 

--- a/Generals/Code/SFMLPlatform/Main.cpp
+++ b/Generals/Code/SFMLPlatform/Main.cpp
@@ -1,0 +1,311 @@
+#include "WindowSystem.h"
+
+#include <Common/CriticalSection.h>
+#include <Common/Debug.h>
+#include <Common/GameMemory.h>
+#include <Common/StackDump.h>
+#include <Common/Version.h>
+#include <Common/GameEngine.h>
+#include <Win32Device/Common/Win32GameEngine.h>
+
+#include <BuildVersion.h>
+#include <GeneratedVersion.h>
+#include <Main/WinMain.h>
+
+#include <SFML/Graphics/RenderWindow.hpp>
+
+#include <algorithm>
+#include <cstring>
+#include <filesystem>
+#include <iostream>
+#include <limits>
+#include <optional>
+#include <system_error>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <eh.h>
+#include <windows.h>
+#endif
+
+using sfml_platform::WindowConfig;
+using sfml_platform::WindowSystem;
+
+namespace {
+
+constexpr unsigned int kDefaultWidth = 1280;
+constexpr unsigned int kDefaultHeight = 720;
+
+enum class BackendOption {
+    Direct3D8,
+    OpenGL,
+};
+
+struct ParsedArguments {
+    WindowConfig config;
+    BackendOption backend = BackendOption::Direct3D8;
+    unsigned int bitDepth = 32;
+    bool helpRequested = false;
+};
+
+CriticalSection critSec1;
+CriticalSection critSec2;
+CriticalSection critSec3;
+CriticalSection critSec4;
+CriticalSection critSec5;
+
+std::vector<std::string> toArgumentVector(int argc, char** argv) {
+    std::vector<std::string> args;
+    args.reserve(static_cast<std::size_t>(argc));
+    for (int i = 0; i < argc; ++i) {
+        args.emplace_back(argv[i] ? argv[i] : "");
+    }
+    return args;
+}
+
+void printHelp() {
+    std::cout << "Command & Conquer Generals (SFML bootstrap)\n"
+              << "Options:\n"
+              << "  -h, --help           Show this message\n"
+              << "  -w, --width <value>  Set the window width (default " << kDefaultWidth << ")\n"
+              << "  -H, --height <value> Set the window height (default " << kDefaultHeight << ")\n"
+              << "  -f, --fullscreen     Start in fullscreen mode\n"
+              << "      --windowed       Force windowed mode\n"
+              << "      --vsync          Enable vertical sync (default)\n"
+              << "      --no-vsync       Disable vertical sync\n"
+              << "      --fps <value>    Limit frames per second (0 = uncapped)\n"
+              << "      --opengl         Use the OpenGL renderer\n"
+              << "      --d3d            Use the Direct3D 8 renderer (default)\n"
+              << "      --bitdepth <n>   Set color bit depth (default 32)\n";
+}
+
+std::optional<unsigned int> parseUnsigned(const std::string& value) {
+    if (value.empty()) {
+        return std::nullopt;
+    }
+
+    try {
+        unsigned long parsed = std::stoul(value);
+        if (parsed > std::numeric_limits<unsigned int>::max()) {
+            return std::nullopt;
+        }
+        return static_cast<unsigned int>(parsed);
+    } catch (const std::exception&) {
+        return std::nullopt;
+    }
+}
+
+ParsedArguments parseArguments(const std::vector<std::string>& arguments) {
+    ParsedArguments result;
+    result.config.width = kDefaultWidth;
+    result.config.height = kDefaultHeight;
+
+    for (std::size_t i = 1; i < arguments.size(); ++i) {
+        const std::string& argument = arguments[i];
+
+        auto consumeValue = [&](const char* longName, const char* shortName) -> std::optional<std::string> {
+            if (argument == longName || (shortName != nullptr && argument == shortName)) {
+                if (i + 1 < arguments.size()) {
+                    return arguments[++i];
+                }
+                std::cerr << "Missing value for option '" << argument << "'\n";
+                return std::nullopt;
+            }
+            return std::nullopt;
+        };
+
+        if (argument == "-h" || argument == "--help") {
+            result.helpRequested = true;
+            return result;
+        }
+
+        if (auto value = consumeValue("--width", "-w")) {
+            if (auto parsed = parseUnsigned(*value)) {
+                result.config.width = *parsed;
+            } else {
+                std::cerr << "Invalid width value: '" << *value << "'\n";
+            }
+            continue;
+        }
+
+        if (auto value = consumeValue("--height", "-H")) {
+            if (auto parsed = parseUnsigned(*value)) {
+                result.config.height = *parsed;
+            } else {
+                std::cerr << "Invalid height value: '" << *value << "'\n";
+            }
+            continue;
+        }
+
+        if (auto value = consumeValue("--fps", nullptr)) {
+            if (auto parsed = parseUnsigned(*value)) {
+                result.config.frameLimit = *parsed;
+            } else {
+                std::cerr << "Invalid FPS limit: '" << *value << "'\n";
+            }
+            continue;
+        }
+
+        if (auto value = consumeValue("--bitdepth", "-bpp")) {
+            if (auto parsed = parseUnsigned(*value)) {
+                result.bitDepth = *parsed;
+            } else {
+                std::cerr << "Invalid bit depth: '" << *value << "'\n";
+            }
+            continue;
+        }
+
+        if (argument == "-f" || argument == "--fullscreen") {
+            result.config.fullscreen = true;
+            continue;
+        }
+
+        if (argument == "--windowed" || argument == "-win" || argument == "-windowed" || argument == "-nowin") {
+            result.config.fullscreen = false;
+            continue;
+        }
+
+        if (argument == "--vsync") {
+            result.config.verticalSync = true;
+            continue;
+        }
+
+        if (argument == "--no-vsync" || argument == "-novsync") {
+            result.config.verticalSync = false;
+            continue;
+        }
+
+        if (argument == "--opengl" || argument == "-opengl") {
+            result.backend = BackendOption::OpenGL;
+            continue;
+        }
+
+        if (argument == "--d3d" || argument == "--direct3d" || argument == "-d3d") {
+            result.backend = BackendOption::Direct3D8;
+            continue;
+        }
+
+        std::cerr << "Unrecognized option: '" << argument << "'\n";
+    }
+
+    return result;
+}
+
+std::vector<char*> buildArgv(const std::vector<std::string>& arguments) {
+    std::vector<char*> argvPointers;
+    argvPointers.reserve(arguments.size());
+    for (const std::string& argument : arguments) {
+        argvPointers.push_back(const_cast<char*>(argument.c_str()));
+    }
+    return argvPointers;
+}
+
+void assignCriticalSections() {
+    TheAsciiStringCriticalSection = &critSec1;
+    TheUnicodeStringCriticalSection = &critSec2;
+    TheDmaCriticalSection = &critSec3;
+    TheMemoryPoolCriticalSection = &critSec4;
+    TheDebugLogCriticalSection = &critSec5;
+}
+
+void clearCriticalSections() {
+    TheAsciiStringCriticalSection = NULL;
+    TheUnicodeStringCriticalSection = NULL;
+    TheDmaCriticalSection = NULL;
+    TheMemoryPoolCriticalSection = NULL;
+    TheDebugLogCriticalSection = NULL;
+}
+
+GraphicsBackend toGraphicsBackend(BackendOption backend) {
+    switch (backend) {
+        case BackendOption::OpenGL:
+            return GRAPHICS_BACKEND_OPENGL;
+        case BackendOption::Direct3D8:
+        default:
+            return GRAPHICS_BACKEND_DIRECT3D8;
+    }
+}
+
+void setWorkingDirectory(const std::vector<std::string>& arguments) {
+    if (arguments.empty()) {
+        return;
+    }
+
+    std::error_code ec;
+    std::filesystem::path executable = std::filesystem::absolute(arguments.front(), ec);
+    if (ec) {
+        return;
+    }
+
+    const auto parent = executable.parent_path();
+    if (!parent.empty()) {
+        std::filesystem::current_path(parent, ec);
+    }
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    const auto arguments = toArgumentVector(argc, argv);
+    ParsedArguments parsed = parseArguments(arguments);
+
+    if (parsed.helpRequested) {
+        printHelp();
+        return 0;
+    }
+
+    setWorkingDirectory(arguments);
+
+    WindowSystem windowSystem;
+    if (!windowSystem.initialize(parsed.config)) {
+        std::cerr << "Failed to create SFML window" << std::endl;
+        return 1;
+    }
+
+#ifdef _WIN32
+    ApplicationHInstance = GetModuleHandle(nullptr);
+    ApplicationHWnd = reinterpret_cast<HWND>(windowSystem.window().getSystemHandle());
+    SetWindowLongPtr(ApplicationHWnd, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(WndProc));
+#else
+    ApplicationHInstance = nullptr;
+    ApplicationHWnd = nullptr;
+#endif
+    ApplicationIsWindowed = !parsed.config.fullscreen;
+    ApplicationGraphicsBackend = toGraphicsBackend(parsed.backend);
+    gInitialEngineActiveState = windowSystem.window().hasFocus() ? TRUE : FALSE;
+
+    assignCriticalSections();
+
+    DEBUG_INIT(DEBUG_FLAGS_DEFAULT);
+    initMemoryManager();
+
+    TheVersion = NEW Version;
+    TheVersion->setVersion(VERSION_MAJOR, VERSION_MINOR, VERSION_BUILDNUM, VERSION_LOCALBUILDNUM,
+                           AsciiString(VERSION_BUILDUSER), AsciiString(VERSION_BUILDLOC),
+                           AsciiString(__TIME__), AsciiString(__DATE__));
+
+    std::vector<char*> argvPointers = buildArgv(arguments);
+
+#ifdef _WIN32
+    _set_se_translator(DumpExceptionInfo);
+#endif
+
+    try {
+        GameMain(static_cast<int>(argvPointers.size()), argvPointers.data());
+    } catch (...) {
+        std::cerr << "Unhandled exception while running GameMain" << std::endl;
+    }
+
+    delete TheVersion;
+    TheVersion = NULL;
+
+    shutdownMemoryManager();
+    DEBUG_SHUTDOWN();
+
+    clearCriticalSections();
+
+    windowSystem.shutdown();
+
+    return 0;
+}

--- a/Generals/Code/SFMLPlatform/WindowConfig.h
+++ b/Generals/Code/SFMLPlatform/WindowConfig.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+
+namespace sfml_platform {
+
+struct WindowConfig {
+    unsigned int width = 1280;
+    unsigned int height = 720;
+    bool fullscreen = false;
+    bool verticalSync = true;
+    unsigned int frameLimit = 0;
+    std::string title = "Command & Conquer Generals";
+};
+
+} // namespace sfml_platform

--- a/Generals/Code/SFMLPlatform/WindowSystem.cpp
+++ b/Generals/Code/SFMLPlatform/WindowSystem.cpp
@@ -1,0 +1,105 @@
+#include "WindowSystem.h"
+
+#include <SFML/Window/Event.hpp>
+#include <SFML/Window/VideoMode.hpp>
+#include <SFML/Window/WindowStyle.hpp>
+#include <SFML/System/Clock.hpp>
+#include <algorithm>
+
+namespace sfml_platform {
+
+namespace {
+
+sf::VideoMode pickVideoMode(unsigned int width, unsigned int height, bool fullscreen) {
+    if (!fullscreen) {
+        return sf::VideoMode(width, height);
+    }
+
+    const auto modes = sf::VideoMode::getFullscreenModes();
+    auto it = std::find_if(modes.begin(), modes.end(), [width, height](const sf::VideoMode& mode) {
+        return mode.width == width && mode.height == height;
+    });
+
+    if (it != modes.end()) {
+        return *it;
+    }
+
+    return modes.empty() ? sf::VideoMode(width, height) : modes.front();
+}
+
+} // namespace
+
+WindowSystem::WindowSystem() = default;
+WindowSystem::~WindowSystem() = default;
+
+bool WindowSystem::initialize(const WindowConfig& config) {
+    m_config = config;
+
+    const auto style = config.fullscreen ? sf::Style::Fullscreen : sf::Style::Default;
+    const auto videoMode = pickVideoMode(config.width, config.height, config.fullscreen);
+
+    m_window.create(videoMode, config.title, style);
+    configureRenderSettings(config);
+    m_running = m_window.isOpen();
+
+    return m_running;
+}
+
+void WindowSystem::configureRenderSettings(const WindowConfig& config) {
+    m_window.setVerticalSyncEnabled(config.verticalSync);
+
+    if (config.frameLimit > 0) {
+        m_window.setFramerateLimit(config.frameLimit);
+    } else {
+        m_window.setFramerateLimit(0);
+    }
+}
+
+void WindowSystem::run(const UpdateHandler& update, const RenderHandler& render, const EventHandler& onEvent) {
+    sf::Clock frameClock;
+
+    while (m_running && m_window.isOpen()) {
+        sf::Event event{};
+        while (m_window.pollEvent(event)) {
+            if (event.type == sf::Event::Closed) {
+                m_window.close();
+            }
+
+            if (onEvent) {
+                onEvent(event);
+            }
+        }
+
+        const float delta = frameClock.restart().asSeconds();
+
+        if (update) {
+            update(m_window, delta);
+        }
+
+        if (render) {
+            render(m_window);
+        } else {
+            m_window.clear();
+            m_window.display();
+        }
+
+        m_running = m_window.isOpen();
+    }
+}
+
+void WindowSystem::shutdown() {
+    if (m_window.isOpen()) {
+        m_window.close();
+    }
+    m_running = false;
+}
+
+sf::RenderWindow& WindowSystem::window() {
+    return m_window;
+}
+
+const sf::RenderWindow& WindowSystem::window() const {
+    return m_window;
+}
+
+} // namespace sfml_platform

--- a/Generals/Code/SFMLPlatform/WindowSystem.h
+++ b/Generals/Code/SFMLPlatform/WindowSystem.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "WindowConfig.h"
+
+#include <SFML/Graphics/RenderWindow.hpp>
+#include <functional>
+
+namespace sfml_platform {
+
+class WindowSystem {
+public:
+    using EventHandler = std::function<void(const sf::Event&)>;
+    using UpdateHandler = std::function<void(sf::RenderWindow&, float)>;
+    using RenderHandler = std::function<void(sf::RenderWindow&)>;
+
+    WindowSystem();
+    ~WindowSystem();
+
+    bool initialize(const WindowConfig& config);
+    void run(const UpdateHandler& update, const RenderHandler& render, const EventHandler& onEvent);
+    void shutdown();
+
+    sf::RenderWindow& window();
+    const sf::RenderWindow& window() const;
+
+private:
+    void configureRenderSettings(const WindowConfig& config);
+
+    WindowConfig m_config;
+    sf::RenderWindow m_window;
+    bool m_running = false;
+};
+
+} // namespace sfml_platform


### PR DESCRIPTION
## Summary
- add an SFML bootstrap entrypoint that parses command-line options, assigns global state, and hands control to the existing GameMain loop
- move WinMain's exported globals into a dedicated module and share a GameEngine factory that preserves the window active flag for both launchers
- teach WinMain to populate the shared active-state flag before entering the engine so both bootstraps produce consistent behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca8f1c43148331b76fea3e9f372dff