### PR TITLE
Add SFML keyboard bridge and decouple DirectInput

### DIFF
--- a/Generals/Code/GameEngine/Include/GameClient/Keyboard.h
+++ b/Generals/Code/GameEngine/Include/GameClient/Keyboard.h
@@ -164,6 +164,12 @@ protected:
 
 };  // end Keyboard
 
+typedef Keyboard *(*KeyboardFactoryFunction)();
+
+void SetKeyboardFactoryOverride( KeyboardFactoryFunction factory );
+KeyboardFactoryFunction GetKeyboardFactoryOverride();
+
+
 // INLINING ///////////////////////////////////////////////////////////////////
 
 // EXTERNALS //////////////////////////////////////////////////////////////////

--- a/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/Generals/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -39,6 +39,23 @@
 // PUBLIC DATA ////////////////////////////////////////////////////////////////////////////////////
 Keyboard *TheKeyboard = NULL;
 
+namespace
+{
+
+KeyboardFactoryFunction g_keyboardFactoryOverride = NULL;
+
+}
+
+void SetKeyboardFactoryOverride( KeyboardFactoryFunction factory )
+{
+	g_keyboardFactoryOverride = factory;
+}
+
+KeyboardFactoryFunction GetKeyboardFactoryOverride()
+{
+	return g_keyboardFactoryOverride;
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // PRIVATE PROTOTYPES /////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -447,8 +464,8 @@ void Keyboard::initKeyNames( void )
 
 			_set_keyname_(L'1',				L'!',				L'\0',	KEY_1  );
 			_set_keyname_(L'2',				L'\"',			L'\0',	KEY_2  );
-			_set_keyname_(L'3',				0x00A3,			L'\0',	KEY_3  );	//£
-			_set_keyname_(L'4',				L'$',				L'€',		KEY_4  );
+			_set_keyname_(L'3',				0x00A3,			L'\0',	KEY_3  );	//Â£
+			_set_keyname_(L'4',				L'$',				L'Â€',		KEY_4  );
 			_set_keyname_(L'5',				L'%',				L'\0',	KEY_5  );
 			_set_keyname_(L'6',				L'^',				L'\0',	KEY_6  );
 			_set_keyname_(L'7',				L'&',				L'\0',	KEY_7  );
@@ -465,7 +482,7 @@ void Keyboard::initKeyNames( void )
 
 			_set_keyname_(L';',				L':',				L'\0',	KEY_SEMICOLON  );
 			_set_keyname_(L'\'',			L'@',				L'\0',	KEY_APOSTROPHE  );
-			_set_keyname_(L'`',				0x00AC,			0x00A6,	KEY_TICK  );	//¬¦
+			_set_keyname_(L'`',				0x00AC,			0x00A6,	KEY_TICK  );	//Â¬Â¦
 			_set_keyname_(L'#',				L'~',				L'\0',	KEY_BACKSLASH  );
 
 			_set_keyname_(L'-',				L'_',				L'\0',	KEY_MINUS  );
@@ -496,7 +513,7 @@ void Keyboard::initKeyNames( void )
 			_set_keyname_(L'j',				L'J',				L'\0',	KEY_J  );
 			_set_keyname_(L'k',				L'K',				L'\0',	KEY_K  );
 			_set_keyname_(L'l',				L'L',				L'\0',	KEY_L  );
-			_set_keyname_(L'm',				L'M',				0x00B5,	KEY_M  );	//µ
+			_set_keyname_(L'm',				L'M',				0x00B5,	KEY_M  );	//Âµ
 			_set_keyname_(L'n',				L'N',				L'\0',	KEY_N  );
 			_set_keyname_(L'o',				L'O',				L'\0',	KEY_O  );
 			_set_keyname_(L'p',				L'P',				L'\0',	KEY_P  );
@@ -512,8 +529,8 @@ void Keyboard::initKeyNames( void )
 			_set_keyname_(L'y',				L'Y',				L'\0',	KEY_Z  );
 
 			_set_keyname_(L'1',				L'!',				L'\0',	KEY_1  );
-			_set_keyname_(L'2',				L'"',				0x00B2,	KEY_2  );	//²
-			_set_keyname_(L'3',				0x00A7,			0x00B3,	KEY_3  );	//§³
+			_set_keyname_(L'2',				L'"',				0x00B2,	KEY_2  );	//Â²
+			_set_keyname_(L'3',				0x00A7,			0x00B3,	KEY_3  );	//Â§Â³
 			_set_keyname_(L'4',				L'$',				L'\0',	KEY_4  );
 			_set_keyname_(L'5',				L'%',				L'\0',	KEY_5  );
 			_set_keyname_(L'6',				L'&',				L'\0',	KEY_6  );
@@ -526,16 +543,16 @@ void Keyboard::initKeyNames( void )
 			_set_keyname_(L'.',				L':',				L'\0',	KEY_PERIOD  );
 			_set_keyname_(L'-',				L'_',				L'\0',	KEY_SLASH  );
 
-			_set_keyname_(0x00FC,			0x00DC,			L'\0',	KEY_LBRACKET  );		//üÜ
+			_set_keyname_(0x00FC,			0x00DC,			L'\0',	KEY_LBRACKET  );		//Ã¼Ãœ
 			_set_keyname_(L'+',				L'*',				L'~',		KEY_RBRACKET  );
 
-			_set_keyname_(0x00F6,			0x00D6,			L'\0',	KEY_SEMICOLON  );		//öÖ
-			_set_keyname_(0x00E4,			0x00C4,			L'\0',	KEY_APOSTROPHE  );	//äÄ
-			_set_keyname_(L'^',				0x00B0,			L'\0',	KEY_TICK  );				//°
+			_set_keyname_(0x00F6,			0x00D6,			L'\0',	KEY_SEMICOLON  );		//Ã¶Ã–
+			_set_keyname_(0x00E4,			0x00C4,			L'\0',	KEY_APOSTROPHE  );	//Ã¤Ã„
+			_set_keyname_(L'^',				0x00B0,			L'\0',	KEY_TICK  );				//Â°
 			_set_keyname_(L'#',				L'\'',			L'\0',	KEY_BACKSLASH  );
 
-			_set_keyname_(0x00DF,			L'?',				L'\\',	KEY_MINUS  );				//ß
-			_set_keyname_(0x00B4,			L'`',				L'\0',	KEY_EQUAL  );				//´
+			_set_keyname_(0x00DF,			L'?',				L'\\',	KEY_MINUS  );				//ÃŸ
+			_set_keyname_(0x00B4,			L'`',				L'\0',	KEY_EQUAL  );				//Â´
 
 			_set_keyname_(L'<',				L'>',				L'|',		KEY_102  );
 
@@ -578,29 +595,29 @@ void Keyboard::initKeyNames( void )
 			_set_keyname_(L'w',				L'W',				L'\0',	KEY_Z  );
 
 			_set_keyname_(L'&',				L'1',				L'\0',	KEY_1  );
-			_set_keyname_(0x00E9,			L'2',				L'~',		KEY_2  );	//é
+			_set_keyname_(0x00E9,			L'2',				L'~',		KEY_2  );	//Ã©
 			_set_keyname_(L'"',				L'3',				L'#',		KEY_3  );
 			_set_keyname_(L'\'',			L'4',				L'{',		KEY_4  );
 			_set_keyname_(L'(',				L'5',				L'[',		KEY_5  );
 			_set_keyname_(L'-',				L'6',				L'|',		KEY_6  );
-			_set_keyname_(0x00E8,			L'7',				L'`',		KEY_7  );	//è
+			_set_keyname_(0x00E8,			L'7',				L'`',		KEY_7  );	//Ã¨
 			_set_keyname_(L'_',				L'8',				L'\\',	KEY_8  );
-			_set_keyname_(0x00E7,			L'9',				L'\0',	KEY_9  );	//ç
-			_set_keyname_(0x00E0,			L'0',				L'@',		KEY_0  );	//à
+			_set_keyname_(0x00E7,			L'9',				L'\0',	KEY_9  );	//Ã§
+			_set_keyname_(0x00E0,			L'0',				L'@',		KEY_0  );	//Ã 
 
 			_set_keyname_(L';',				L'.',				L'\0',	KEY_COMMA  );
 			_set_keyname_(L':',				L'/',				L'\0',	KEY_PERIOD  );
-			_set_keyname_(L'!',				0x00A7,			L'\0',	KEY_SLASH  );				//§
+			_set_keyname_(L'!',				0x00A7,			L'\0',	KEY_SLASH  );				//Â§
 
-			_set_keyname_(L'^',				0x00A8,			L'\0',	KEY_LBRACKET  );		//¨
-			_set_keyname_(L'$',				0x00A3,			0x00A4,	KEY_RBRACKET  );		//£¤
+			_set_keyname_(L'^',				0x00A8,			L'\0',	KEY_LBRACKET  );		//Â¨
+			_set_keyname_(L'$',				0x00A3,			0x00A4,	KEY_RBRACKET  );		//Â£Â¤
 
 			_set_keyname_(L'm',				L'M',				L'\0',	KEY_SEMICOLON  );
-			_set_keyname_(0x00F9,			L'%',				L'\0',	KEY_APOSTROPHE  );	//ù
-			_set_keyname_(0x00B2,			L'\0',			L'\0',	KEY_TICK  );				//²
-			_set_keyname_(L'*',				0x00B5,			L'\0',	KEY_BACKSLASH  );		//µ
+			_set_keyname_(0x00F9,			L'%',				L'\0',	KEY_APOSTROPHE  );	//Ã¹
+			_set_keyname_(0x00B2,			L'\0',			L'\0',	KEY_TICK  );				//Â²
+			_set_keyname_(L'*',				0x00B5,			L'\0',	KEY_BACKSLASH  );		//Âµ
 
-			_set_keyname_(L')',				0x00B0,			L']',		KEY_MINUS  );				//°
+			_set_keyname_(L')',				0x00B0,			L']',		KEY_MINUS  );				//Â°
 			_set_keyname_(L'=',				L'+',				L'}',		KEY_EQUAL  );
 
 			_set_keyname_(L'<',				L'>',				L'\0',	KEY_102  );
@@ -645,7 +662,7 @@ void Keyboard::initKeyNames( void )
 
 			_set_keyname_(L'1',				L'!',				L'\0',	KEY_1  );
 			_set_keyname_(L'2',				L'"',				L'\0',	KEY_2  );
-			_set_keyname_(L'3',				0x00A3,			L'\0',	KEY_3  );		//£
+			_set_keyname_(L'3',				0x00A3,			L'\0',	KEY_3  );		//Â£
 			_set_keyname_(L'4',				L'$',				L'\0',	KEY_4  );
 			_set_keyname_(L'5',				L'%',				L'\0',	KEY_5  );
 			_set_keyname_(L'6',				L'&',				L'\0',	KEY_6  );
@@ -658,16 +675,16 @@ void Keyboard::initKeyNames( void )
 			_set_keyname_(L'.',				L':',				L'\0',	KEY_PERIOD  );
 			_set_keyname_(L'-',				L'_',				L'\0',	KEY_SLASH  );
 
-			_set_keyname_(0x00E8,			0x00E9,			L'[',		KEY_LBRACKET  );		//èé
+			_set_keyname_(0x00E8,			0x00E9,			L'[',		KEY_LBRACKET  );		//Ã¨Ã©
 			_set_keyname_(L'+',				L'*',				L']',		KEY_RBRACKET  );
 
-			_set_keyname_(0x00F2,			0x00E7,			L'@',		KEY_SEMICOLON  );		//òç
-			_set_keyname_(0x00E0,			0x00B0,			L'#',		KEY_APOSTROPHE  );	//à°
+			_set_keyname_(0x00F2,			0x00E7,			L'@',		KEY_SEMICOLON  );		//Ã²Ã§
+			_set_keyname_(0x00E0,			0x00B0,			L'#',		KEY_APOSTROPHE  );	//Ã Â°
 			_set_keyname_(L'\\',			L'|',				L'\0',	KEY_TICK  );
-			_set_keyname_(0x00F9,			0x00A7,			L'\0',	KEY_BACKSLASH  );		//ù§
+			_set_keyname_(0x00F9,			0x00A7,			L'\0',	KEY_BACKSLASH  );		//Ã¹Â§
 
 			_set_keyname_(L'\'',			L'?',				L'\0',	KEY_MINUS  );
-			_set_keyname_(0x00EC,			L'^',				L'\0',	KEY_EQUAL  );				//ì
+			_set_keyname_(0x00EC,			L'^',				L'\0',	KEY_EQUAL  );				//Ã¬
 
 			_set_keyname_(L'<',				L'>',				L'\0',	KEY_102  );
 

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameClient.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameClient.h
@@ -41,6 +41,7 @@
 
 // USER INCLUDES //////////////////////////////////////////////////////////////
 #include "GameClient/GameClient.h"
+#include "GameClient/Keyboard.h"
 #include "W3DDevice/GameClient/W3DParticleSys.h"
 #include "W3DDevice/GameClient/W3DDisplay.h"
 #include "W3DDevice/GameClient/W3DInGameUI.h"
@@ -49,7 +50,9 @@
 #include "W3DDevice/GameClient/W3DGameFont.h"
 #include "W3DDevice/GameClient/W3DDisplayStringManager.h"
 #include "VideoDevice/Bink/BinkVideoPlayer.h"
+#if defined(ENABLE_LEGACY_DIRECTINPUT)
 #include "Win32Device/GameClient/Win32DIKeyboard.h"
+#endif
 #include "Win32Device/GameClient/Win32DIMouse.h"
 #include "Win32Device/GameClient/Win32Mouse.h"
 #include "W3DDevice/GameClient/W3DMouse.h"
@@ -118,7 +121,6 @@ protected:
 
 };  // end class W3DGameClient
 
-inline Keyboard *W3DGameClient::createKeyboard( void ) { return NEW DirectInputKeyboard; }
 inline Mouse *W3DGameClient::createMouse( void )
 {
 	//return new DirectInputMouse;

--- a/Generals/Code/GameEngineDevice/Include/Win32Device/GameClient/Win32DIKeyboard.h
+++ b/Generals/Code/GameEngineDevice/Include/Win32Device/GameClient/Win32DIKeyboard.h
@@ -49,6 +49,8 @@
 #ifndef __WIN32DIKEYBOARD_H_
 #define __WIN32DIKEYBOARD_H_
 
+#ifdef ENABLE_LEGACY_DIRECTINPUT
+
 // SYSTEM INCLUDES ////////////////////////////////////////////////////////////
 #ifndef DIRECTINPUT_VERSION
 #	define DIRECTINPUT_VERSION	0x800
@@ -101,6 +103,8 @@ protected:
 // INLINING ///////////////////////////////////////////////////////////////////
 
 // EXTERNALS //////////////////////////////////////////////////////////////////
+
+#endif // ENABLE_LEGACY_DIRECTINPUT
 
 #endif // __WIN32DIKEYBOARD_H_
 

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DGameClient.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DGameClient.cpp
@@ -44,6 +44,7 @@
 #include "Common/RandomValue.h"
 #include "Common/GlobalData.h"
 #include "Common/GameLOD.h"
+#include "Common/Debug.h"
 #include "GameClient/Drawable.h"
 #include "GameClient/GameClient.h"
 #include "GameClient/ParticleSys.h"
@@ -72,6 +73,26 @@ W3DGameClient::~W3DGameClient()
 {
 
 }  // end ~W3DGameClient
+
+Keyboard *W3DGameClient::createKeyboard( void )
+{
+	KeyboardFactoryFunction factory = GetKeyboardFactoryOverride();
+	if( factory )
+	{
+		Keyboard *keyboard = factory();
+		if( keyboard )
+		{
+			return keyboard;
+		}
+	}
+
+#if defined(ENABLE_LEGACY_DIRECTINPUT)
+	return NEW DirectInputKeyboard;
+#else
+	DEBUG_FATAL(( "No keyboard factory registered and legacy DirectInput support disabled." ));
+	return NULL;
+#endif
+}
 
 //-------------------------------------------------------------------------------------------------
 /** Initialize resources for the w3d game client */

--- a/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIKeyboard.cpp
+++ b/Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIKeyboard.cpp
@@ -28,6 +28,8 @@
 //						using Microsoft Direct Input
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
+#ifdef ENABLE_LEGACY_DIRECTINPUT
+
 #include <windows.h>
 #include <assert.h>
 
@@ -423,3 +425,5 @@ Bool DirectInputKeyboard::getCapsState( void )
 	return BitTest( GetKeyState( VK_CAPITAL ), 0X01);
 
 }  // end getCapsState
+
+#endif // ENABLE_LEGACY_DIRECTINPUT

--- a/Generals/Code/SFMLPlatform/Main.cpp
+++ b/Generals/Code/SFMLPlatform/Main.cpp
@@ -1,10 +1,12 @@
 #include "WindowSystem.h"
+#include "SfmlKeyboardBridge.h"
 
 #include <Common/CriticalSection.h>
 #include <Common/Debug.h>
 #include <Common/GameMemory.h>
 #include <Common/StackDump.h>
 #include <Common/Version.h>
+#include <GameClient/Keyboard.h>
 #include <Common/GameEngine.h>
 #include <Win32Device/Common/Win32GameEngine.h>
 
@@ -290,6 +292,8 @@ int main(int argc, char** argv) {
 #ifdef _WIN32
     _set_se_translator(DumpExceptionInfo);
 #endif
+
+    SetKeyboardFactoryOverride(sfml_platform::CreateSfmlKeyboard);
 
     try {
         GameMain(static_cast<int>(argvPointers.size()), argvPointers.data());

--- a/Generals/Code/SFMLPlatform/SfmlKeyboardBridge.cpp
+++ b/Generals/Code/SFMLPlatform/SfmlKeyboardBridge.cpp
@@ -1,0 +1,275 @@
+/*
+**      Command & Conquer Generals(tm)
+**      Copyright 2025 Electronic Arts Inc.
+**
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
+**
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
+**
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                                                                             /
+//
+//  (c) 2001-2003 Electronic Arts Inc.                                                                                         /
+//
+//                                                                                                                             /
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// FILE: SfmlKeyboardBridge.cpp ///////////////////////////////////////////////
+
+#include "SfmlKeyboardBridge.h"
+
+#include "GameClient/KeyDefs.h"
+
+#include <SFML/Window/Event.hpp>
+#include <SFML/Window/Keyboard.hpp>
+
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
+namespace sfml_platform
+{
+
+namespace
+{
+
+SfmlKeyboardBridge *g_activeKeyboardBridge = NULL;
+
+UnsignedByte translateKeyCode( sf::Keyboard::Key key )
+{
+        using sf::Keyboard;
+
+        switch( key )
+        {
+        case Keyboard::A: return KEY_A;
+        case Keyboard::B: return KEY_B;
+        case Keyboard::C: return KEY_C;
+        case Keyboard::D: return KEY_D;
+        case Keyboard::E: return KEY_E;
+        case Keyboard::F: return KEY_F;
+        case Keyboard::G: return KEY_G;
+        case Keyboard::H: return KEY_H;
+        case Keyboard::I: return KEY_I;
+        case Keyboard::J: return KEY_J;
+        case Keyboard::K: return KEY_K;
+        case Keyboard::L: return KEY_L;
+        case Keyboard::M: return KEY_M;
+        case Keyboard::N: return KEY_N;
+        case Keyboard::O: return KEY_O;
+        case Keyboard::P: return KEY_P;
+        case Keyboard::Q: return KEY_Q;
+        case Keyboard::R: return KEY_R;
+        case Keyboard::S: return KEY_S;
+        case Keyboard::T: return KEY_T;
+        case Keyboard::U: return KEY_U;
+        case Keyboard::V: return KEY_V;
+        case Keyboard::W: return KEY_W;
+        case Keyboard::X: return KEY_X;
+        case Keyboard::Y: return KEY_Y;
+        case Keyboard::Z: return KEY_Z;
+
+        case Keyboard::Num0: return KEY_0;
+        case Keyboard::Num1: return KEY_1;
+        case Keyboard::Num2: return KEY_2;
+        case Keyboard::Num3: return KEY_3;
+        case Keyboard::Num4: return KEY_4;
+        case Keyboard::Num5: return KEY_5;
+        case Keyboard::Num6: return KEY_6;
+        case Keyboard::Num7: return KEY_7;
+        case Keyboard::Num8: return KEY_8;
+        case Keyboard::Num9: return KEY_9;
+
+        case Keyboard::Escape: return KEY_ESC;
+        case Keyboard::LControl: return KEY_LCTRL;
+        case Keyboard::LShift: return KEY_LSHIFT;
+        case Keyboard::LAlt: return KEY_LALT;
+        case Keyboard::RControl: return KEY_RCTRL;
+        case Keyboard::RShift: return KEY_RSHIFT;
+        case Keyboard::RAlt: return KEY_RALT;
+        case Keyboard::Menu: return KEY_SYSREQ;
+
+        case Keyboard::LBracket: return KEY_LBRACKET;
+        case Keyboard::RBracket: return KEY_RBRACKET;
+        case Keyboard::Semicolon: return KEY_SEMICOLON;
+        case Keyboard::Comma: return KEY_COMMA;
+        case Keyboard::Period: return KEY_PERIOD;
+        case Keyboard::Quote: return KEY_APOSTROPHE;
+        case Keyboard::Slash: return KEY_SLASH;
+        case Keyboard::Backslash: return KEY_BACKSLASH;
+        case Keyboard::Tilde: return KEY_TICK;
+        case Keyboard::Equal: return KEY_EQUAL;
+        case Keyboard::Hyphen: return KEY_MINUS;
+
+        case Keyboard::Space: return KEY_SPACE;
+        case Keyboard::Enter: return KEY_ENTER;
+        case Keyboard::Backspace: return KEY_BACKSPACE;
+        case Keyboard::Tab: return KEY_TAB;
+        case Keyboard::PageUp: return KEY_PGUP;
+        case Keyboard::PageDown: return KEY_PGDN;
+        case Keyboard::End: return KEY_END;
+        case Keyboard::Home: return KEY_HOME;
+        case Keyboard::Insert: return KEY_INS;
+        case Keyboard::Delete: return KEY_DEL;
+
+        case Keyboard::Add: return KEY_KPPLUS;
+        case Keyboard::Subtract: return KEY_KPMINUS;
+        case Keyboard::Multiply: return KEY_KPSTAR;
+        case Keyboard::Divide: return KEY_KPSLASH;
+
+        case Keyboard::Left: return KEY_LEFT;
+        case Keyboard::Right: return KEY_RIGHT;
+        case Keyboard::Up: return KEY_UP;
+        case Keyboard::Down: return KEY_DOWN;
+
+        case Keyboard::Numpad0: return KEY_KP0;
+        case Keyboard::Numpad1: return KEY_KP1;
+        case Keyboard::Numpad2: return KEY_KP2;
+        case Keyboard::Numpad3: return KEY_KP3;
+        case Keyboard::Numpad4: return KEY_KP4;
+        case Keyboard::Numpad5: return KEY_KP5;
+        case Keyboard::Numpad6: return KEY_KP6;
+        case Keyboard::Numpad7: return KEY_KP7;
+        case Keyboard::Numpad8: return KEY_KP8;
+        case Keyboard::Numpad9: return KEY_KP9;
+
+        case Keyboard::F1: return KEY_F1;
+        case Keyboard::F2: return KEY_F2;
+        case Keyboard::F3: return KEY_F3;
+        case Keyboard::F4: return KEY_F4;
+        case Keyboard::F5: return KEY_F5;
+        case Keyboard::F6: return KEY_F6;
+        case Keyboard::F7: return KEY_F7;
+        case Keyboard::F8: return KEY_F8;
+        case Keyboard::F9: return KEY_F9;
+        case Keyboard::F10: return KEY_F10;
+        case Keyboard::F11: return KEY_F11;
+        case Keyboard::F12: return KEY_F12;
+
+        case Keyboard::Pause: return KEY_SCROLL;
+
+        default:
+                break;
+        }
+
+        return KEY_NONE;
+}
+
+} // namespace
+
+SfmlKeyboardBridge::SfmlKeyboardBridge()
+        : m_nextSequence( 1 )
+        , m_capsLockActive( FALSE )
+        , m_capsLockKeyDown( FALSE )
+{
+#if defined(_WIN32)
+        if( GetKeyState( VK_CAPITAL ) & 0x01 )
+        {
+                m_capsLockActive = TRUE;
+                m_modifiers |= KEY_STATE_CAPSLOCK;
+        }
+#endif
+
+        g_activeKeyboardBridge = this;
+}
+
+SfmlKeyboardBridge::~SfmlKeyboardBridge()
+{
+        if( g_activeKeyboardBridge == this )
+        {
+                g_activeKeyboardBridge = NULL;
+        }
+}
+
+Bool SfmlKeyboardBridge::getCapsState( void )
+{
+        return m_capsLockActive;
+}
+
+void SfmlKeyboardBridge::handleEvent( const sf::Event &event )
+{
+        if( event.type != sf::Event::KeyPressed && event.type != sf::Event::KeyReleased )
+        {
+                return;
+        }
+
+        UnsignedShort state = (event.type == sf::Event::KeyPressed) ? KEY_STATE_DOWN : KEY_STATE_UP;
+        UnsignedByte key = translateKeyCode( event.key.code );
+
+        if( key == KEY_NONE )
+        {
+                return;
+        }
+
+        if( key == KEY_CAPS )
+        {
+                if( state == KEY_STATE_DOWN )
+                {
+                        if( !m_capsLockKeyDown )
+                        {
+                                m_capsLockActive = !m_capsLockActive;
+                                m_capsLockKeyDown = TRUE;
+                        }
+                }
+                else
+                {
+                        m_capsLockKeyDown = FALSE;
+                }
+        }
+
+        enqueueKey( key, state );
+}
+
+void SfmlKeyboardBridge::getKey( KeyboardIO *key )
+{
+        if( key == NULL )
+        {
+                return;
+        }
+
+        if( m_pendingEvents.empty() )
+        {
+                key->key = KEY_NONE;
+                key->state = KEY_STATE_NONE;
+                key->status = KeyboardIO::STATUS_UNUSED;
+                key->sequence = 0;
+                return;
+        }
+
+        *key = m_pendingEvents.front();
+        m_pendingEvents.pop_front();
+}
+
+void SfmlKeyboardBridge::enqueueKey( UnsignedByte key, UnsignedShort state )
+{
+        KeyboardIO entry;
+        entry.key = key;
+        entry.status = KeyboardIO::STATUS_UNUSED;
+        entry.state = state;
+        entry.sequence = m_nextSequence++;
+
+        m_pendingEvents.push_back( entry );
+}
+
+SfmlKeyboardBridge *GetActiveKeyboardBridge()
+{
+        return g_activeKeyboardBridge;
+}
+
+Keyboard *CreateSfmlKeyboard()
+{
+        return new SfmlKeyboardBridge;
+}
+
+} // namespace sfml_platform
+

--- a/Generals/Code/SFMLPlatform/SfmlKeyboardBridge.h
+++ b/Generals/Code/SFMLPlatform/SfmlKeyboardBridge.h
@@ -1,0 +1,88 @@
+/*
+**      Command & Conquer Generals(tm)
+**      Copyright 2025 Electronic Arts Inc.
+**
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
+**
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
+**
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                                                                             /
+//
+//  (c) 2001-2003 Electronic Arts Inc.                                                                                         /
+//
+//                                                                                                                             /
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// FILE: SfmlKeyboardBridge.h //////////////////////////////////////////////////
+//-----------------------------------------------------------------------------
+//
+//  SFML keyboard bridge that adapts sf::Event key input to the legacy
+//  GameClient::Keyboard API.
+//
+//-----------------------------------------------------------------------------
+///////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#ifndef SFML_KEYBOARD_BRIDGE_H
+#define SFML_KEYBOARD_BRIDGE_H
+
+// SYSTEM INCLUDES ////////////////////////////////////////////////////////////
+#include <deque>
+
+// USER INCLUDES //////////////////////////////////////////////////////////////
+#include "GameClient/Keyboard.h"
+
+// FORWARD DECLARATIONS ///////////////////////////////////////////////////////
+namespace sf
+{
+        class Event;
+}
+
+namespace sfml_platform
+{
+
+class SfmlKeyboardBridge : public Keyboard
+{
+public:
+
+        SfmlKeyboardBridge();
+        virtual ~SfmlKeyboardBridge();
+
+        virtual Bool getCapsState( void );
+
+        void handleEvent( const sf::Event &event );
+
+protected:
+
+        virtual void getKey( KeyboardIO *key );
+
+private:
+
+        void enqueueKey( UnsignedByte key, UnsignedShort state );
+
+        std::deque< KeyboardIO > m_pendingEvents;
+        UnsignedInt m_nextSequence;
+        Bool m_capsLockActive;
+        Bool m_capsLockKeyDown;
+};
+
+SfmlKeyboardBridge *GetActiveKeyboardBridge();
+Keyboard *CreateSfmlKeyboard();
+
+} // namespace sfml_platform
+
+#endif // SFML_KEYBOARD_BRIDGE_H
+

--- a/Generals/Code/SFMLPlatform/WindowSystem.cpp
+++ b/Generals/Code/SFMLPlatform/WindowSystem.cpp
@@ -1,5 +1,7 @@
 #include "WindowSystem.h"
 
+#include "SfmlKeyboardBridge.h"
+
 #include <SFML/Window/Event.hpp>
 #include <SFML/Window/VideoMode.hpp>
 #include <SFML/Window/WindowStyle.hpp>
@@ -61,6 +63,10 @@ void WindowSystem::run(const UpdateHandler& update, const RenderHandler& render,
     while (m_running && m_window.isOpen()) {
         sf::Event event{};
         while (m_window.pollEvent(event)) {
+            if (auto* keyboard = GetActiveKeyboardBridge()) {
+                keyboard->handleEvent(event);
+            }
+
             if (event.type == sf::Event::Closed) {
                 m_window.close();
             }


### PR DESCRIPTION
## Summary
- add an SfmlKeyboardBridge that translates SFML key events into the existing Keyboard subsystem and exposes the active adapter
- allow registering a keyboard factory override and make the W3D client prefer it, falling back to legacy DirectInput only when ENABLE_LEGACY_DIRECTINPUT is defined
- wire the SFML bootstrap to install the bridge, forward window events to it, and wrap the DirectInput implementation behind the legacy flag

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca996d45d88331b1930112cca22788