### PR TITLE
Replace DX8 index buffers with bgfx handles

### DIFF
--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/RenderBackend.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/RenderBackend.h
@@ -1,0 +1,46 @@
+/*
+**      Command & Conquer Generals(tm)
+**      Copyright 2025 Electronic Arts Inc.
+**
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
+**
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
+**
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+//
+//  (c) 2001-2003 Electronic Arts Inc.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// FILE: RenderBackend.h ///////////////////////////////////////////////////////
+//
+// Interface describing the active renderer backend used by the game.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef W3DDEVICE_GAMECLIENT_RENDERBACKEND_H
+#define W3DDEVICE_GAMECLIENT_RENDERBACKEND_H
+
+class IRenderBackend
+{
+public:
+    virtual ~IRenderBackend() {}
+
+    virtual void HandleFocusChange(bool isActive) = 0;
+};
+
+void SetRenderBackend(IRenderBackend* backend);
+IRenderBackend& GetRenderBackend();
+
+#endif  // W3DDEVICE_GAMECLIENT_RENDERBACKEND_H
+

--- a/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/RenderBackend.cpp
+++ b/Generals/Code/GameEngineDevice/Source/W3DDevice/GameClient/RenderBackend.cpp
@@ -1,0 +1,61 @@
+/*
+**      Command & Conquer Generals(tm)
+**      Copyright 2025 Electronic Arts Inc.
+**
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
+**
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
+**
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+//
+//  (c) 2001-2003 Electronic Arts Inc.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// FILE: RenderBackend.cpp /////////////////////////////////////////////////////
+//
+// Storage for the active renderer backend instance.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "W3DDevice/GameClient/RenderBackend.h"
+
+namespace
+{
+class NullRenderBackend : public IRenderBackend
+{
+public:
+    virtual void HandleFocusChange(bool) {}
+};
+
+NullRenderBackend g_nullRenderBackend;
+IRenderBackend* g_activeRenderBackend = &g_nullRenderBackend;
+}
+
+void SetRenderBackend(IRenderBackend* backend)
+{
+    if (backend)
+    {
+        g_activeRenderBackend = backend;
+    }
+    else
+    {
+        g_activeRenderBackend = &g_nullRenderBackend;
+    }
+}
+
+IRenderBackend& GetRenderBackend()
+{
+    return *g_activeRenderBackend;
+}
+

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8indexbuffer.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8indexbuffer.h
@@ -52,6 +52,7 @@ class DX8Wrapper;
 class SortingRendererClass;
 struct IDirect3DIndexBuffer8;
 class DX8IndexBufferClass;
+struct DX8IndexBufferBgfxData;
 class SortingIndexBufferClass;
 
 // ----------------------------------------------------------------------------
@@ -181,8 +182,12 @@ public:
 
 	inline IDirect3DIndexBuffer8* Get_DX8_Index_Buffer()	{ return index_buffer; }
 	
+	unsigned short* Lock(unsigned offset_bytes, unsigned size_bytes, unsigned flags);
+	void Unlock();
+
 private:
 	IDirect3DIndexBuffer8*	index_buffer;		// actual dx8 index buffer
+	DX8IndexBufferBgfxData* m_bgfxData;
 };
 
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.cpp
@@ -45,6 +45,14 @@
 #include "thread.h"
 #include <D3dx8core.h>
 
+#if __has_include(<bgfx/bgfx.h>)
+#define WW3D_BGFX_VERTEX_AVAILABLE 1
+#include <bgfx/bgfx.h>
+#include <vector>
+#else
+#define WW3D_BGFX_VERTEX_AVAILABLE 0
+#endif
+
 #define DEFAULT_VB_SIZE 5000
 
 static bool _DynamicSortingVertexArrayInUse=false;
@@ -65,6 +73,71 @@ static int _DX8VertexBufferCount=0;
 static int _VertexBufferCount;
 static int _VertexBufferTotalVertices;
 static int _VertexBufferTotalSize;
+
+#if WW3D_BGFX_VERTEX_AVAILABLE
+static uint8_t Get_TexCoord_Component_Count(unsigned fvf, unsigned stage)
+{
+        if ((fvf & D3DFVF_TEXCOORDSIZE1(stage)) == D3DFVF_TEXCOORDSIZE1(stage)) return 1;
+        if ((fvf & D3DFVF_TEXCOORDSIZE2(stage)) == D3DFVF_TEXCOORDSIZE2(stage)) return 2;
+        if ((fvf & D3DFVF_TEXCOORDSIZE3(stage)) == D3DFVF_TEXCOORDSIZE3(stage)) return 3;
+        if ((fvf & D3DFVF_TEXCOORDSIZE4(stage)) == D3DFVF_TEXCOORDSIZE4(stage)) return 4;
+        return 2;
+}
+
+struct DX8VertexBufferBgfxData
+{
+        DX8VertexBufferBgfxData(bool is_dynamic, uint32_t stride_bytes, uint32_t vertex_count)
+                : dynamic(is_dynamic),
+                  lock_active(false),
+                  stride(stride_bytes),
+                  vertex_count(vertex_count),
+                  lock_offset(0),
+                  lock_size(0),
+                  data(stride_bytes * vertex_count)
+        {
+                dynamic_handle.idx = bgfx::kInvalidHandle;
+                static_handle.idx = bgfx::kInvalidHandle;
+        }
+
+        bool dynamic;
+        bool lock_active;
+        uint32_t stride;
+        uint32_t vertex_count;
+        uint32_t lock_offset;
+        uint32_t lock_size;
+        std::vector<unsigned char> data;
+        bgfx::VertexLayout layout;
+        bgfx::DynamicVertexBufferHandle dynamic_handle;
+        bgfx::VertexBufferHandle static_handle;
+};
+
+static void Build_Bgfx_Vertex_Layout(const FVFInfoClass& info, bgfx::VertexLayout& layout)
+{
+        const unsigned fvf = info.Get_FVF();
+        layout.begin();
+        layout.add(bgfx::Attrib::Position, 3, bgfx::AttribType::Float);
+        if ((fvf & D3DFVF_NORMAL) == D3DFVF_NORMAL)
+        {
+                layout.add(bgfx::Attrib::Normal, 3, bgfx::AttribType::Float);
+        }
+        if ((fvf & D3DFVF_DIFFUSE) == D3DFVF_DIFFUSE)
+        {
+                layout.add(bgfx::Attrib::Color0, 4, bgfx::AttribType::Uint8, true);
+        }
+        if ((fvf & D3DFVF_SPECULAR) == D3DFVF_SPECULAR)
+        {
+                layout.add(bgfx::Attrib::Color1, 4, bgfx::AttribType::Uint8, true);
+        }
+
+        const uint32_t tex_count = (fvf & D3DFVF_TEXCOUNT_MASK) >> D3DFVF_TEXCOUNT_SHIFT;
+        for (uint32_t stage = 0; stage < tex_count; ++stage)
+        {
+                bgfx::Attrib::Enum attrib = static_cast<bgfx::Attrib::Enum>(bgfx::Attrib::TexCoord0 + stage);
+                layout.add(attrib, Get_TexCoord_Component_Count(fvf, stage), bgfx::AttribType::Float);
+        }
+        layout.end();
+}
+#endif // WW3D_BGFX_VERTEX_AVAILABLE
 
 // ----------------------------------------------------------------------------
 //
@@ -169,12 +242,10 @@ VertexBufferClass::WriteLockClass::WriteLockClass(VertexBufferClass* VertexBuffe
 			fvf_name));
 		}
 #endif
-		DX8_Assert();
-		DX8_ErrorCode(static_cast<DX8VertexBufferClass*>(VertexBuffer)->Get_DX8_Vertex_Buffer()->Lock(
-			0,
-			0,
-			(unsigned char**)&Vertices,
-			0));	// Default (no) flags
+		Vertices = static_cast<DX8VertexBufferClass*>(VertexBuffer)->Lock(
+				0,
+				0,
+				0);
 		break;
 	case BUFFER_TYPE_SORTING:
 		Vertices=static_cast<SortingVertexBufferClass*>(VertexBuffer)->VertexBuffer;
@@ -195,8 +266,7 @@ VertexBufferClass::WriteLockClass::~WriteLockClass()
 #ifdef VERTEX_BUFFER_LOG
 		WWDEBUG_SAY(("VertexBuffer->Unlock()\n"));
 #endif
-		DX8_Assert();
-		DX8_ErrorCode(static_cast<DX8VertexBufferClass*>(VertexBuffer)->Get_DX8_Vertex_Buffer()->Unlock());
+		static_cast<DX8VertexBufferClass*>(VertexBuffer)->Unlock();
 		break;
 	case BUFFER_TYPE_SORTING:
 		break;
@@ -235,12 +305,10 @@ VertexBufferClass::AppendLockClass::AppendLockClass(VertexBufferClass* VertexBuf
 			fvf_name));
 		}
 #endif
-		DX8_Assert();
-		DX8_ErrorCode(static_cast<DX8VertexBufferClass*>(VertexBuffer)->Get_DX8_Vertex_Buffer()->Lock(
-			start_index*VertexBuffer->FVF_Info().Get_FVF_Size(),
-			index_range*VertexBuffer->FVF_Info().Get_FVF_Size(),
-			(unsigned char**)&Vertices,
-			0));	// Default (no) flags
+		Vertices = static_cast<DX8VertexBufferClass*>(VertexBuffer)->Lock(
+				start_index*VertexBuffer->FVF_Info().Get_FVF_Size(),
+				index_range*VertexBuffer->FVF_Info().Get_FVF_Size(),
+				0);
 		break;
 	case BUFFER_TYPE_SORTING:
 		Vertices=static_cast<SortingVertexBufferClass*>(VertexBuffer)->VertexBuffer+start_index;
@@ -258,11 +326,10 @@ VertexBufferClass::AppendLockClass::~AppendLockClass()
 	DX8_THREAD_ASSERT();
 	switch (VertexBuffer->Type()) {
 	case BUFFER_TYPE_DX8:
-		DX8_Assert();
 #ifdef VERTEX_BUFFER_LOG
 		WWDEBUG_SAY(("VertexBuffer->Unlock()\n"));
 #endif
-		DX8_ErrorCode(static_cast<DX8VertexBufferClass*>(VertexBuffer)->Get_DX8_Vertex_Buffer()->Unlock());
+		static_cast<DX8VertexBufferClass*>(VertexBuffer)->Unlock();
 		break;
 	case BUFFER_TYPE_SORTING:
 		break;
@@ -305,7 +372,8 @@ SortingVertexBufferClass::~SortingVertexBufferClass()
 DX8VertexBufferClass::DX8VertexBufferClass(unsigned FVF, unsigned short vertex_count_, UsageType usage)
 	:
 	VertexBufferClass(BUFFER_TYPE_DX8, FVF, vertex_count_),
-	VertexBuffer(NULL)
+	VertexBuffer(NULL),
+	m_bgfxData(NULL)
 {
 	Create_Vertex_Buffer(usage);
 }
@@ -320,7 +388,8 @@ DX8VertexBufferClass::DX8VertexBufferClass(
 	UsageType usage)
 	:
 	VertexBufferClass(BUFFER_TYPE_DX8, D3DFVF_XYZ|D3DFVF_TEX1|D3DFVF_NORMAL, VertexCount),
-	VertexBuffer(NULL)
+	VertexBuffer(NULL),
+	m_bgfxData(NULL)
 {
 	WWASSERT(vertices);
 	WWASSERT(normals);
@@ -341,7 +410,8 @@ DX8VertexBufferClass::DX8VertexBufferClass(
 	UsageType usage)
 	:
 	VertexBufferClass(BUFFER_TYPE_DX8, D3DFVF_XYZ|D3DFVF_TEX1|D3DFVF_NORMAL|D3DFVF_DIFFUSE, VertexCount),
-	VertexBuffer(NULL)
+	VertexBuffer(NULL),
+	m_bgfxData(NULL)
 {
 	WWASSERT(vertices);
 	WWASSERT(normals);
@@ -362,7 +432,8 @@ DX8VertexBufferClass::DX8VertexBufferClass(
 	UsageType usage)
 	:
 	VertexBufferClass(BUFFER_TYPE_DX8, D3DFVF_XYZ|D3DFVF_TEX1|D3DFVF_DIFFUSE, VertexCount),
-	VertexBuffer(NULL)
+	VertexBuffer(NULL),
+	m_bgfxData(NULL)
 {
 	WWASSERT(vertices);
 	WWASSERT(tex_coords);
@@ -381,7 +452,8 @@ DX8VertexBufferClass::DX8VertexBufferClass(
 	UsageType usage)
 	:
 	VertexBufferClass(BUFFER_TYPE_DX8, D3DFVF_XYZ|D3DFVF_TEX1, VertexCount),
-	VertexBuffer(NULL)
+	VertexBuffer(NULL),
+	m_bgfxData(NULL)
 {
 	WWASSERT(vertices);
 	WWASSERT(tex_coords);
@@ -394,12 +466,35 @@ DX8VertexBufferClass::DX8VertexBufferClass(
 
 DX8VertexBufferClass::~DX8VertexBufferClass()
 {
-#ifdef VERTEX_BUFFER_LOG
-	WWDEBUG_SAY(("VertexBuffer->Release()\n"));
-	_DX8VertexBufferCount--;
-	WWDEBUG_SAY(("Current vertex buffer count: %d\n",_DX8VertexBufferCount));
+#if WW3D_BGFX_VERTEX_AVAILABLE
+        if (m_bgfxData)
+        {
+                if (m_bgfxData->dynamic)
+                {
+                        if (bgfx::isValid(m_bgfxData->dynamic_handle))
+                        {
+                                bgfx::destroy(m_bgfxData->dynamic_handle);
+                        }
+                }
+                else if (bgfx::isValid(m_bgfxData->static_handle))
+                {
+                        bgfx::destroy(m_bgfxData->static_handle);
+                }
+                delete m_bgfxData;
+                m_bgfxData = NULL;
+        }
 #endif
-	VertexBuffer->Release();
+
+        if (VertexBuffer)
+        {
+#ifdef VERTEX_BUFFER_LOG
+                WWDEBUG_SAY(("VertexBuffer->Release()\n"));
+                _DX8VertexBufferCount--;
+                WWDEBUG_SAY(("Current vertex buffer count: %d\n",_DX8VertexBufferCount));
+#endif
+                VertexBuffer->Release();
+                VertexBuffer = NULL;
+        }
 }
 
 // ----------------------------------------------------------------------------
@@ -410,14 +505,30 @@ DX8VertexBufferClass::~DX8VertexBufferClass()
 
 void DX8VertexBufferClass::Create_Vertex_Buffer(UsageType usage)
 {
-	DX8_THREAD_ASSERT();
-	WWASSERT(!VertexBuffer);
+        DX8_THREAD_ASSERT();
+        WWASSERT(!VertexBuffer);
+
+#if WW3D_BGFX_VERTEX_AVAILABLE
+        if (DX8Wrapper::Is_Bgfx_Active())
+        {
+                WWASSERT(m_bgfxData == NULL);
+                m_bgfxData = W3DNEW DX8VertexBufferBgfxData((usage & USAGE_DYNAMIC) != 0, FVF_Info().Get_FVF_Size(), VertexCount);
+                Build_Bgfx_Vertex_Layout(FVF_Info(), m_bgfxData->layout);
+
+                if (m_bgfxData->dynamic)
+                {
+                        m_bgfxData->dynamic_handle = bgfx::createDynamicVertexBuffer(VertexCount, m_bgfxData->layout);
+                }
+
+                return;
+        }
+#endif
 
 #ifdef VERTEX_BUFFER_LOG
-	StringClass fvf_name;
-	FVF_Info().Get_FVF_Name(fvf_name);
-	WWDEBUG_SAY(("CreateVertexBuffer(fvfsize=%d, vertex_count=%d, D3DUSAGE_WRITEONLY|%s|%s, fvf: %s, %s)\n",
-		FVF_Info().Get_FVF_Size(),
+        StringClass fvf_name;
+        FVF_Info().Get_FVF_Name(fvf_name);
+        WWDEBUG_SAY(("CreateVertexBuffer(fvfsize=%d, vertex_count=%d, D3DUSAGE_WRITEONLY|%s|%s, fvf: %s, %s)\n",
+                FVF_Info().Get_FVF_Size(),
 		VertexCount,
 		usage&USAGE_DYNAMIC ? "D3DUSAGE_DYNAMIC" : "-",
 		usage&USAGE_SOFTWAREPROCESSING ? "D3DUSAGE_SOFTWAREPROCESSING" : "-",
@@ -481,15 +592,97 @@ void DX8VertexBufferClass::Create_Vertex_Buffer(UsageType usage)
 		FVF_Info().Get_FVF(),
 		(usage&USAGE_DYNAMIC) ? D3DPOOL_DEFAULT : D3DPOOL_MANAGED,
 		&VertexBuffer));
-	*/
+        */
+}
+
+// ----------------------------------------------------------------------------
+
+void* DX8VertexBufferClass::Lock(unsigned offset_bytes, unsigned size_bytes, unsigned flags)
+{
+#if WW3D_BGFX_VERTEX_AVAILABLE
+        if (m_bgfxData)
+        {
+                const uint32_t total_size = static_cast<uint32_t>(m_bgfxData->data.size());
+                if (offset_bytes >= total_size)
+                {
+                        return NULL;
+                }
+
+                uint32_t range = size_bytes ? size_bytes : (total_size - offset_bytes);
+                if (offset_bytes + range > total_size)
+                {
+                        range = total_size - offset_bytes;
+                }
+
+                m_bgfxData->lock_offset = offset_bytes;
+                m_bgfxData->lock_size = range;
+                m_bgfxData->lock_active = true;
+
+                return &m_bgfxData->data[offset_bytes];
+        }
+#endif
+
+        unsigned char* bytes = NULL;
+        DX8_ErrorCode(VertexBuffer->Lock(offset_bytes, size_bytes, &bytes, flags));
+        return bytes;
+}
+
+// ----------------------------------------------------------------------------
+
+void DX8VertexBufferClass::Unlock()
+{
+#if WW3D_BGFX_VERTEX_AVAILABLE
+        if (m_bgfxData)
+        {
+                const uint32_t total_size = static_cast<uint32_t>(m_bgfxData->data.size());
+                uint32_t offset = m_bgfxData->lock_offset;
+                uint32_t range = m_bgfxData->lock_size ? m_bgfxData->lock_size : (total_size - offset);
+
+                if (offset < total_size && range)
+                {
+                        if (offset + range > total_size)
+                        {
+                                range = total_size - offset;
+                        }
+
+                        if (m_bgfxData->dynamic)
+                        {
+                                if (bgfx::isValid(m_bgfxData->dynamic_handle))
+                                {
+                                        WWASSERT((offset % m_bgfxData->stride) == 0);
+                                        WWASSERT((range % m_bgfxData->stride) == 0);
+                                        const bgfx::Memory* memory = bgfx::copy(&m_bgfxData->data[offset], range);
+                                        const uint32_t vertex_offset = offset / m_bgfxData->stride;
+                                        bgfx::update(m_bgfxData->dynamic_handle, vertex_offset, memory);
+                                }
+                        }
+                        else
+                        {
+                                const bgfx::Memory* memory = bgfx::copy(m_bgfxData->data.data(), total_size);
+                                if (bgfx::isValid(m_bgfxData->static_handle))
+                                {
+                                        bgfx::destroy(m_bgfxData->static_handle);
+                                }
+                                m_bgfxData->static_handle = bgfx::createVertexBuffer(memory, m_bgfxData->layout);
+                        }
+                }
+
+                m_bgfxData->lock_active = false;
+                m_bgfxData->lock_offset = 0;
+                m_bgfxData->lock_size = 0;
+                return;
+        }
+#endif
+
+        DX8_ErrorCode(VertexBuffer->Unlock());
 }
 
 // ----------------------------------------------------------------------------
 
 void DX8VertexBufferClass::Copy(const Vector3* loc, const Vector3* norm, const Vector2* uv, unsigned first_vertex,unsigned count)
 {
-	WWASSERT(loc);
-	WWASSERT(norm);
+        WWASSERT(loc);
+        WWASSERT(norm);
 	WWASSERT(uv);
 	WWASSERT(count<=VertexCount);
 	WWASSERT(FVF_Info().Get_FVF()==DX8_FVF_XYZNUV1);
@@ -839,13 +1032,11 @@ DynamicVBAccessClass::WriteLockClass::WriteLockClass(DynamicVBAccessClass* dynam
 		WWASSERT(_DynamicDX8VertexBuffer);
 //		WWASSERT(!_DynamicDX8VertexBuffer->Engine_Refs());
 
-		DX8_Assert();
 		// Lock with discard contents if the buffer offset is zero
-		DX8_ErrorCode(static_cast<DX8VertexBufferClass*>(DynamicVBAccess->VertexBuffer)->Get_DX8_Vertex_Buffer()->Lock(
-			DynamicVBAccess->VertexBufferOffset*_DynamicDX8VertexBuffer->FVF_Info().Get_FVF_Size(),
-			DynamicVBAccess->Get_Vertex_Count()*DynamicVBAccess->VertexBuffer->FVF_Info().Get_FVF_Size(),
-			(unsigned char**)&Vertices,
-			D3DLOCK_NOSYSLOCK | (!DynamicVBAccess->VertexBufferOffset ? D3DLOCK_DISCARD : D3DLOCK_NOOVERWRITE)));
+		Vertices = static_cast<DX8VertexBufferClass*>(DynamicVBAccess->VertexBuffer)->Lock(
+				DynamicVBAccess->VertexBufferOffset*_DynamicDX8VertexBuffer->FVF_Info().Get_FVF_Size(),
+				DynamicVBAccess->Get_Vertex_Count()*DynamicVBAccess->VertexBuffer->FVF_Info().Get_FVF_Size(),
+				D3DLOCK_NOSYSLOCK | (!DynamicVBAccess->VertexBufferOffset ? D3DLOCK_DISCARD : D3DLOCK_NOOVERWRITE));
 		break;
 	case BUFFER_TYPE_DYNAMIC_SORTING:
 		Vertices=static_cast<SortingVertexBufferClass*>(DynamicVBAccess->VertexBuffer)->VertexBuffer;
@@ -870,8 +1061,7 @@ DynamicVBAccessClass::WriteLockClass::~WriteLockClass()
 		WWASSERT(!dx8_lock);
 		WWDEBUG_SAY(("DynamicVertexBuffer->Unlock()\n"));
 #endif
-		DX8_Assert();
-		DX8_ErrorCode(static_cast<DX8VertexBufferClass*>(DynamicVBAccess->VertexBuffer)->Get_DX8_Vertex_Buffer()->Unlock());
+		static_cast<DX8VertexBufferClass*>(VertexBuffer)->Unlock();
 		break;
 	case BUFFER_TYPE_DYNAMIC_SORTING:
 		break;

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.h
@@ -61,6 +61,7 @@ class FVFInfoClass;
 struct IDirect3DVertexBuffer8;
 class VertexBufferClass;
 struct VertexFormatXYZNDUV2;
+struct DX8VertexBufferBgfxData;
 
 class VertexBufferLockClass
 {
@@ -224,6 +225,9 @@ public:
 
 	IDirect3DVertexBuffer8* Get_DX8_Vertex_Buffer() { return VertexBuffer; }
 
+	void* Lock(unsigned offset_bytes, unsigned size_bytes, unsigned flags);
+	void Unlock();
+
 	void Copy(const Vector3* loc, unsigned first_vertex, unsigned count);
 	void Copy(const Vector3* loc, const Vector2* uv, unsigned first_vertex, unsigned count);
 	void Copy(const Vector3* loc, const Vector3* norm, unsigned first_vertex, unsigned count);
@@ -233,6 +237,7 @@ public:
 
 protected:
 	IDirect3DVertexBuffer8*		VertexBuffer;
+	DX8VertexBufferBgfxData*		m_bgfxData;
 
 	void Create_Vertex_Buffer(UsageType usage);
 };

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -75,6 +75,18 @@
 #include "bound.h"
 #include "dx8webbrowser.h"
 
+#if defined(__has_include)
+#if __has_include(<bgfx/bgfx.h>)
+#include <bgfx/bgfx.h>
+#include <bgfx/platform.h>
+#define WW3D_BGFX_AVAILABLE 1
+#else
+#define WW3D_BGFX_AVAILABLE 0
+#endif
+#else
+#define WW3D_BGFX_AVAILABLE 0
+#endif
+
 #define WW3D_DEVTYPE D3DDEVTYPE_HAL
 
 const int DEFAULT_RESOLUTION_WIDTH = 640;
@@ -157,6 +169,22 @@ static DynamicVectorClass<StringClass>					_RenderDeviceNameTable;
 static DynamicVectorClass<StringClass>					_RenderDeviceShortNameTable;
 static DynamicVectorClass<RenderDeviceDescClass>	_RenderDeviceDescriptionTable;
 
+static GraphicsBackend g_activeBackend = GRAPHICS_BACKEND_DIRECT3D8;
+
+#if WW3D_BGFX_AVAILABLE
+struct BgfxDeviceState
+{
+	bool initialized;
+	void* windowHandle;
+};
+
+static BgfxDeviceState g_bgfxState = { false, NULL };
+#endif
+
+static void PopulateBgfxDeviceDescriptions();
+static bool InitializeBgfx(void* hwnd);
+static void ShutdownBgfx();
+
 /*
 ** Registry value names
 */
@@ -195,9 +223,9 @@ void Log_DX8_ErrorCode(unsigned res)
 
 void Non_Fatal_Log_DX8_ErrorCode(unsigned res,const char * file,int line)
 {
-	char tmp[256]="";
+        char tmp[256]="";
 
-	HRESULT new_res=D3DXGetErrorStringA(
+        HRESULT new_res=D3DXGetErrorStringA(
 		res,
 		tmp,
 		sizeof(tmp));
@@ -208,14 +236,125 @@ void Non_Fatal_Log_DX8_ErrorCode(unsigned res,const char * file,int line)
 }
 
 
+static void PopulateBgfxDeviceDescriptions()
+{
+        StringClass device_name = "bgfx";
+        _RenderDeviceNameTable.Add(device_name);
+        _RenderDeviceShortNameTable.Add(device_name);
+
+        RenderDeviceDescClass desc;
+        desc.set_device_name("bgfx");
+        desc.set_device_platform("bgfx");
+        desc.set_driver_name("bgfx");
+        desc.set_driver_vendor("bgfx");
+        desc.set_driver_version("1.0.0");
+        desc.set_hardware_name("bgfx");
+        desc.set_hardware_vendor("bgfx");
+        desc.set_hardware_chipset("bgfx");
+        desc.reset_resolution_list();
+
+        static const int kResolutions[][2] = {
+                { 640, 480 },
+                { 800, 600 },
+                { 1024, 768 },
+                { 1280, 720 },
+                { 1280, 1024 },
+                { 1600, 900 },
+                { 1920, 1080 },
+        };
+
+        for (unsigned int idx = 0; idx < sizeof(kResolutions) / sizeof(kResolutions[0]); ++idx)
+        {
+                desc.add_resolution(kResolutions[idx][0], kResolutions[idx][1], DEFAULT_BIT_DEPTH);
+        }
+
+        _RenderDeviceDescriptionTable.Add(desc);
+}
+
+static bool InitializeBgfx(void* hwnd)
+{
+#if WW3D_BGFX_AVAILABLE
+        g_bgfxState.windowHandle = hwnd;
+        g_bgfxState.initialized = false;
+
+        _Hwnd = (HWND)hwnd;
+        _MainThreadID = ThreadClass::_Get_Current_Thread_ID();
+        CurRenderDevice = -1;
+        ResolutionWidth = DEFAULT_RESOLUTION_WIDTH;
+        ResolutionHeight = DEFAULT_RESOLUTION_HEIGHT;
+        Render2DClass::Set_Screen_Resolution(RectClass(0, 0, ResolutionWidth, ResolutionHeight));
+        BitDepth = DEFAULT_BIT_DEPTH;
+        TextureBitDepth = DEFAULT_TEXTURE_BIT_DEPTH;
+        IsWindowed = false;
+        DX8Wrapper_IsWindowed = false;
+
+        Reset_Statistics();
+        Invalidate_Cached_Render_States();
+
+        _RenderDeviceNameTable.Clear();
+        _RenderDeviceShortNameTable.Clear();
+        _RenderDeviceDescriptionTable.Clear();
+        PopulateBgfxDeviceDescriptions();
+
+        bgfx::PlatformData platformData;
+        ::memset(&platformData, 0, sizeof(platformData));
+        platformData.nwh = hwnd;
+        bgfx::setPlatformData(platformData);
+
+        bgfx::Init initArgs;
+        ::memset(&initArgs, 0, sizeof(initArgs));
+        initArgs.type = bgfx::RendererType::Count;
+        initArgs.resolution.width = static_cast<uint32_t>(ResolutionWidth);
+        initArgs.resolution.height = static_cast<uint32_t>(ResolutionHeight);
+        initArgs.resolution.reset = BGFX_RESET_VSYNC;
+
+        if (!bgfx::init(initArgs))
+        {
+                return false;
+        }
+
+        IsInitted = true;
+        g_bgfxState.initialized = true;
+        Set_Default_Global_Render_States();
+        return true;
+#else
+        WWDEBUG_SAY(("bgfx backend selected but bgfx headers are not available.\n"));
+        (void)hwnd;
+        return false;
+#endif
+}
+
+static void ShutdownBgfx()
+{
+#if WW3D_BGFX_AVAILABLE
+        if (g_bgfxState.initialized)
+        {
+                bgfx::shutdown();
+                g_bgfxState.initialized = false;
+        }
+#endif
+
+        _RenderDeviceNameTable.Clear();
+        _RenderDeviceShortNameTable.Clear();
+        _RenderDeviceDescriptionTable.Clear();
+        IsInitted = false;
+        _Hwnd = NULL;
+}
+
+
 bool DX8Wrapper::Init(void * hwnd)
 {
-	WWASSERT(!IsInitted);
+        WWASSERT(!IsInitted);
 
-	/*
-	** Initialize all variables!
-	*/
-	_Hwnd = (HWND)hwnd;
+        if (g_activeBackend == GRAPHICS_BACKEND_BGFX)
+        {
+                return InitializeBgfx(hwnd);
+        }
+
+        /*
+        ** Initialize all variables!
+        */
+        _Hwnd = (HWND)hwnd;
 	_MainThreadID=ThreadClass::_Get_Current_Thread_ID();
 	CurRenderDevice = -1;
 	ResolutionWidth = DEFAULT_RESOLUTION_WIDTH;
@@ -263,10 +402,16 @@ bool DX8Wrapper::Init(void * hwnd)
 
 void DX8Wrapper::Shutdown(void)
 {
-	if (D3DDevice) {
-		Set_Render_Target ((IDirect3DSurface8 *)NULL);
-		Release_Device();
-	}
+        if (g_activeBackend == GRAPHICS_BACKEND_BGFX)
+        {
+                ShutdownBgfx();
+                return;
+        }
+
+        if (D3DDevice) {
+                Set_Render_Target ((IDirect3DSurface8 *)NULL);
+                Release_Device();
+        }
 
 	for (int i = 0; i < MAX_TEXTURE_STAGES; i++) {
 		if (Textures[i]) {
@@ -326,10 +471,33 @@ void DX8Wrapper::Do_Onetime_Device_Dependent_Inits(void)
 }
 
 inline DWORD F2DW(float f) { return *((unsigned*)&f); }
+
+static void Set_Default_Global_Render_States_Bgfx()
+{
+        DX8Wrapper::Set_DX8_Render_State(D3DRS_RANGEFOGENABLE, FALSE);
+        DX8Wrapper::Set_DX8_Render_State(D3DRS_FOGTABLEMODE, D3DFOG_NONE);
+        DX8Wrapper::Set_DX8_Render_State(D3DRS_FOGVERTEXMODE, D3DFOG_LINEAR);
+        DX8Wrapper::Set_DX8_Render_State(D3DRS_SPECULARMATERIALSOURCE, D3DMCS_MATERIAL);
+        DX8Wrapper::Set_DX8_Render_State(D3DRS_COLORVERTEX, TRUE);
+        DX8Wrapper::Set_DX8_Render_State(D3DRS_ZBIAS,0);
+        DX8Wrapper::Set_DX8_Texture_Stage_State(1, D3DTSS_BUMPENVLSCALE, F2DW(1.0f));
+        DX8Wrapper::Set_DX8_Texture_Stage_State(1, D3DTSS_BUMPENVLOFFSET, F2DW(0.0f));
+        DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_BUMPENVMAT00,F2DW(1.0f));
+        DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_BUMPENVMAT01,F2DW(0.0f));
+        DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_BUMPENVMAT10,F2DW(0.0f));
+        DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_BUMPENVMAT11,F2DW(1.0f));
+}
 void DX8Wrapper::Set_Default_Global_Render_States(void)
 {
-	DX8_THREAD_ASSERT();
-	const D3DCAPS8 &caps = DX8Caps::Get_Default_Caps();
+        DX8_THREAD_ASSERT();
+
+        if (Is_Bgfx_Active())
+        {
+                Set_Default_Global_Render_States_Bgfx();
+                return;
+        }
+
+        const D3DCAPS8 &caps = DX8Caps::Get_Default_Caps();
 
 	Set_DX8_Render_State(D3DRS_RANGEFOGENABLE, (caps.RasterCaps & D3DPRASTERCAPS_FOGRANGE) ? TRUE : FALSE);
 	Set_DX8_Render_State(D3DRS_FOGTABLEMODE, D3DFOG_NONE);
@@ -360,24 +528,32 @@ bool DX8Wrapper::Validate_Device(void)
 
 void DX8Wrapper::Invalidate_Cached_Render_States(void)
 {
-	render_state_changed = 0;
+        DX8_THREAD_ASSERT();
+        render_state_changed = 0;
 
-	int a;
-	for (a=0;a<sizeof(RenderStates)/sizeof(unsigned);++a) {
-		RenderStates[a]=0x12345678;
-	}
-	for (a=0;a<MAX_TEXTURE_STAGES;++a) {
-		for (int b=0; b<32;b++) {
-			TextureStageStates[a][b]=0x12345678;
-		}
-		//Need to explicitly set texture to NULL, otherwise app will not be able to
-		//set it to null because of redundant state checker. MW
-		if (_Get_D3D_Device8())
-			_Get_D3D_Device8()->SetTexture(a,NULL);
-		if (Textures[a] != NULL)
-			Textures[a]->Release();
-		Textures[a]=NULL;
-	}
+        int a;
+        for (a=0;a<sizeof(RenderStates)/sizeof(unsigned);++a) {
+                RenderStates[a]=0x12345678;
+        }
+        for (a=0;a<MAX_TEXTURE_STAGES;++a) {
+                for (int b=0; b<32;b++) {
+                        TextureStageStates[a][b]=0x12345678;
+                }
+                //Need to explicitly set texture to NULL, otherwise app will not be able to
+                //set it to null because of redundant state checker. MW
+                if (!Is_Bgfx_Active())
+                {
+                        if (_Get_D3D_Device8())
+                        {
+                                _Get_D3D_Device8()->SetTexture(a,NULL);
+                        }
+                        if (Textures[a] != NULL)
+                        {
+                                Textures[a]->Release();
+                        }
+                }
+                Textures[a]=NULL;
+        }
 	ShaderClass::Invalidate();
 	//Need to explicitly set render_state texture pointers to NULL. MW
 	Release_Render_State();
@@ -537,9 +713,14 @@ void DX8Wrapper::Release_Device(void)
 
 void DX8Wrapper::Enumerate_Devices()
 {
-	DX8_Assert();
+        DX8_Assert();
 
-	int adapter_count = D3DInterface->GetAdapterCount();
+        if (g_activeBackend == GRAPHICS_BACKEND_BGFX)
+        {
+                return;
+        }
+
+        int adapter_count = D3DInterface->GetAdapterCount();
 	for (int adapter_index=0; adapter_index<adapter_count; adapter_index++) {
 		
 		D3DADAPTER_IDENTIFIER8 id;
@@ -2653,4 +2834,20 @@ void DX8Wrapper::Set_Gamma(float gamma,float bright,float contrast,bool calibrat
 WW3DFormat	DX8Wrapper::getBackBufferFormat( void )
 {
 	return D3DFormat_To_WW3DFormat( _PresentParameters.BackBufferFormat );
+}
+
+
+void DX8Wrapper::Set_Active_Backend(GraphicsBackend backend)
+{
+        g_activeBackend = backend;
+}
+
+GraphicsBackend DX8Wrapper::Get_Active_Backend()
+{
+        return g_activeBackend;
+}
+
+bool DX8Wrapper::Is_Bgfx_Active()
+{
+        return g_activeBackend == GRAPHICS_BACKEND_BGFX;
 }

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -58,6 +58,7 @@
 #include "dx8vertexbuffer.h"
 #include "dx8indexbuffer.h"
 #include "vertmaterial.h"
+#include "Main/GraphicsBackend.h"
 
 const unsigned MAX_TEXTURE_STAGES=2;
 
@@ -225,11 +226,15 @@ class DX8Wrapper
 
 public:
 #ifdef EXTENDED_STATS
-	static DX8_Stats stats;
+        static DX8_Stats stats;
 #endif
-	
-	static bool Init(void * hwnd);
-	static void Shutdown(void);
+
+        static void Set_Active_Backend(GraphicsBackend backend);
+        static GraphicsBackend Get_Active_Backend();
+        static bool Is_Bgfx_Active();
+
+        static bool Init(void * hwnd);
+        static void Shutdown(void);
 
 	static void SetCleanupHook(DX8_CleanupHook *pCleanupHook) {m_pCleanupHook = pCleanupHook;};
 	/*
@@ -610,27 +615,49 @@ WWINLINE void DX8Wrapper::Set_Fog(bool enable, const Vector3 &color, float start
 
 WWINLINE void DX8Wrapper::Set_DX8_Material(const D3DMATERIAL8* mat)
 {
-	DX8_RECORD_MATERIAL_CHANGE();
-	WWASSERT(mat);
-	SNAPSHOT_SAY(("DX8 - SetMaterial\n"));
-	DX8CALL(SetMaterial(mat));
+        if (Is_Bgfx_Active())
+        {
+                DX8_RECORD_MATERIAL_CHANGE();
+                return;
+        }
+
+        DX8_RECORD_MATERIAL_CHANGE();
+        WWASSERT(mat);
+        SNAPSHOT_SAY(("DX8 - SetMaterial\n"));
+        DX8CALL(SetMaterial(mat));
 }
 
 WWINLINE void DX8Wrapper::Set_DX8_Light(int index, D3DLIGHT8* light)
 {
-	if (light) {
-		DX8_RECORD_LIGHT_CHANGE();
-		DX8CALL(SetLight(index,light));
-		DX8CALL(LightEnable(index,TRUE));
-		CurrentDX8LightEnables[index]=true;
-		SNAPSHOT_SAY(("DX8 - SetLight\n"));
-	}
-	else if (CurrentDX8LightEnables[index]) {
-		DX8_RECORD_LIGHT_CHANGE();
-		CurrentDX8LightEnables[index]=false;
-		DX8CALL(LightEnable(index,FALSE));
-		SNAPSHOT_SAY(("DX8 - DisableLight\n"));
-	}
+        if (light) {
+                if (Is_Bgfx_Active())
+                {
+                        DX8_RECORD_LIGHT_CHANGE();
+                        CurrentDX8LightEnables[index]=true;
+                        SNAPSHOT_SAY(("DX8 - SetLight\n"));
+                        return;
+                }
+
+                DX8_RECORD_LIGHT_CHANGE();
+                DX8CALL(SetLight(index,light));
+                DX8CALL(LightEnable(index,TRUE));
+                CurrentDX8LightEnables[index]=true;
+                SNAPSHOT_SAY(("DX8 - SetLight\n"));
+        }
+        else if (CurrentDX8LightEnables[index]) {
+                if (Is_Bgfx_Active())
+                {
+                        DX8_RECORD_LIGHT_CHANGE();
+                        CurrentDX8LightEnables[index]=false;
+                        SNAPSHOT_SAY(("DX8 - DisableLight\n"));
+                        return;
+                }
+
+                DX8_RECORD_LIGHT_CHANGE();
+                CurrentDX8LightEnables[index]=false;
+                DX8CALL(LightEnable(index,FALSE));
+                SNAPSHOT_SAY(("DX8 - DisableLight\n"));
+        }
 }
 
 WWINLINE void DX8Wrapper::Set_DX8_Render_State(D3DRENDERSTATETYPE state, unsigned value)
@@ -640,14 +667,25 @@ WWINLINE void DX8Wrapper::Set_DX8_Render_State(D3DRENDERSTATETYPE state, unsigne
 
 	SNAPSHOT_SAY(("DX8 - SetRenderState(%d,%d)\n",state,value));
 
-	RenderStates[state]=value;
-	DX8CALL(SetRenderState( state, value ));
-	DX8_RECORD_RENDER_STATE_CHANGE();
+        RenderStates[state]=value;
+        if (Is_Bgfx_Active())
+        {
+                DX8_RECORD_RENDER_STATE_CHANGE();
+                return;
+        }
+
+        DX8CALL(SetRenderState( state, value ));
+        DX8_RECORD_RENDER_STATE_CHANGE();
 }
 
 WWINLINE void DX8Wrapper::Set_DX8_Clip_Plane(DWORD Index, CONST float* pPlane)
 {
-	DX8CALL(SetClipPlane( Index, pPlane ));
+        if (Is_Bgfx_Active())
+        {
+                return;
+        }
+
+        DX8CALL(SetClipPlane( Index, pPlane ));
 }
 
 WWINLINE void DX8Wrapper::Set_DX8_Texture_Stage_State(unsigned stage, D3DTEXTURESTAGESTATETYPE state, unsigned value)
@@ -660,11 +698,17 @@ WWINLINE void DX8Wrapper::Set_DX8_Texture_Stage_State(unsigned stage, D3DTEXTURE
 	// Can't monitor state changes because setShader call to GERD may change the states!
 	if (TextureStageStates[stage][(unsigned int)state]==value) return;
 
-	SNAPSHOT_SAY(("DX8 - SetTextureStageState(%d,%d,%d)\n",stage,state,value));
+        SNAPSHOT_SAY(("DX8 - SetTextureStageState(%d,%d,%d)\n",stage,state,value));
 
-	TextureStageStates[stage][(unsigned int)state]=value;
-	DX8CALL(SetTextureStageState( stage, state, value ));
-	DX8_RECORD_TEXTURE_STAGE_STATE_CHANGE();
+        TextureStageStates[stage][(unsigned int)state]=value;
+        if (Is_Bgfx_Active())
+        {
+                DX8_RECORD_TEXTURE_STAGE_STATE_CHANGE();
+                return;
+        }
+
+        DX8CALL(SetTextureStageState( stage, state, value ));
+        DX8_RECORD_TEXTURE_STAGE_STATE_CHANGE();
 }
 
 WWINLINE void DX8Wrapper::Set_DX8_Texture(unsigned int stage, IDirect3DBaseTexture8* texture)
@@ -674,15 +718,24 @@ WWINLINE void DX8Wrapper::Set_DX8_Texture(unsigned int stage, IDirect3DBaseTextu
   		return;
   	}
 
-	if (Textures[stage]==texture) return;
+        if (Textures[stage]==texture) return;
 
-	SNAPSHOT_SAY(("DX8 - SetTexture(%x) \n",texture));
+        SNAPSHOT_SAY(("DX8 - SetTexture(%x) \n",texture));
 
-	if (Textures[stage]) Textures[stage]->Release();
-	Textures[stage] = texture;
-	if (Textures[stage]) Textures[stage]->AddRef();
-	DX8CALL(SetTexture(stage, texture));
-	DX8_RECORD_TEXTURE_CHANGE();
+        if (!Is_Bgfx_Active())
+        {
+                if (Textures[stage]) Textures[stage]->Release();
+        }
+
+        Textures[stage] = texture;
+
+        if (!Is_Bgfx_Active())
+        {
+                if (Textures[stage]) Textures[stage]->AddRef();
+                DX8CALL(SetTexture(stage, texture));
+        }
+
+        DX8_RECORD_TEXTURE_CHANGE();
 }
 
 WWINLINE void DX8Wrapper::_Copy_DX8_Rects(

--- a/Generals/Code/Main/GraphicsBackend.h
+++ b/Generals/Code/Main/GraphicsBackend.h
@@ -1,0 +1,42 @@
+/*
+**      Command & Conquer Generals(tm)
+**      Copyright 2025 Electronic Arts Inc.
+**
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
+**
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
+**
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+//
+//  (c) 2001-2003 Electronic Arts Inc.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// FILE: GraphicsBackend.h //////////////////////////////////////////////////////
+//
+// Enumeration describing the available rendering backends.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef MAIN_GRAPHICSBACKEND_H
+#define MAIN_GRAPHICSBACKEND_H
+
+enum GraphicsBackend
+{
+        GRAPHICS_BACKEND_DIRECT3D8 = 0,
+        GRAPHICS_BACKEND_OPENGL,
+        GRAPHICS_BACKEND_BGFX,
+};
+
+#endif  // MAIN_GRAPHICSBACKEND_H
+

--- a/Generals/Code/Main/WinMain.cpp
+++ b/Generals/Code/Main/WinMain.cpp
@@ -65,6 +65,7 @@
 #include "GameClient/IMEManager.h"
 #include "Win32Device/GameClient/Win32Mouse.h"
 #include "Win32Device/Common/Win32GameEngine.h"
+#include "W3DDevice/GameClient/RenderBackend.h"
 #include "Common/Version.h"
 #include "BuildVersion.h"
 #include "GeneratedVersion.h"
@@ -80,8 +81,6 @@ static HANDLE GeneralsMutex = NULL;
 #define GENERALS_GUID "685EAFF2-3216-4265-B047-251C5F4B82F3"
 #define DEFAULT_XRESOLUTION 800
 #define DEFAULT_YRESOLUTION 600
-
-extern void Reset_D3D_Device(bool active);
 
 static Bool gInitializing = false;
 static Bool gDoPaint = true;
@@ -536,7 +535,7 @@ LRESULT CALLBACK WndProc( HWND hWnd, UINT message,
 					if (TheGameEngine)
 						TheGameEngine->setIsActive(isWinMainActive);
 
-					Reset_D3D_Device(isWinMainActive);
+					GetRenderBackend().HandleFocusChange(isWinMainActive != FALSE);
 					if (isWinMainActive)
 					{	//restore mouse cursor to our custom version.
 						if (TheWin32Mouse)

--- a/Generals/Code/Main/WinMain.h
+++ b/Generals/Code/Main/WinMain.h
@@ -37,6 +37,7 @@
 #include <windows.h>
 
 // USER INCLUDES //////////////////////////////////////////////////////////////
+#include "GraphicsBackend.h"
 #include "Win32Device/GameClient/Win32Mouse.h"
 
 // EXTERNAL ///////////////////////////////////////////////////////////////////
@@ -44,12 +45,6 @@ extern HINSTANCE ApplicationHInstance;  ///< our application instance
 extern HWND ApplicationHWnd;  ///< our application window handle
 extern HDC ApplicationHDC;  ///< device context for the primary window (OpenGL)
 extern HGLRC ApplicationHGLRC; ///< OpenGL rendering context
-
-enum GraphicsBackend
-{
-        GRAPHICS_BACKEND_DIRECT3D8 = 0,
-        GRAPHICS_BACKEND_OPENGL
-};
 
 extern GraphicsBackend ApplicationGraphicsBackend; ///< active rendering backend
 extern Win32Mouse *TheWin32Mouse;  ///< global for win32 mouse only!

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/RenderBackend.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/RenderBackend.h
@@ -1,0 +1,46 @@
+/*
+**      Command & Conquer Generals(tm)
+**      Copyright 2025 Electronic Arts Inc.
+**
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
+**
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
+**
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+//
+//  (c) 2001-2003 Electronic Arts Inc.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// FILE: RenderBackend.h ///////////////////////////////////////////////////////
+//
+// Interface describing the active renderer backend used by the game.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef W3DDEVICE_GAMECLIENT_RENDERBACKEND_H
+#define W3DDEVICE_GAMECLIENT_RENDERBACKEND_H
+
+class IRenderBackend
+{
+public:
+    virtual ~IRenderBackend() {}
+
+    virtual void HandleFocusChange(bool isActive) = 0;
+};
+
+void SetRenderBackend(IRenderBackend* backend);
+IRenderBackend& GetRenderBackend();
+
+#endif  // W3DDEVICE_GAMECLIENT_RENDERBACKEND_H
+

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/RenderBackend.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/RenderBackend.cpp
@@ -1,0 +1,61 @@
+/*
+**      Command & Conquer Generals(tm)
+**      Copyright 2025 Electronic Arts Inc.
+**
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
+**
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
+**
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+//
+//  (c) 2001-2003 Electronic Arts Inc.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// FILE: RenderBackend.cpp /////////////////////////////////////////////////////
+//
+// Storage for the active renderer backend instance.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "W3DDevice/GameClient/RenderBackend.h"
+
+namespace
+{
+class NullRenderBackend : public IRenderBackend
+{
+public:
+    virtual void HandleFocusChange(bool) {}
+};
+
+NullRenderBackend g_nullRenderBackend;
+IRenderBackend* g_activeRenderBackend = &g_nullRenderBackend;
+}
+
+void SetRenderBackend(IRenderBackend* backend)
+{
+    if (backend)
+    {
+        g_activeRenderBackend = backend;
+    }
+    else
+    {
+        g_activeRenderBackend = &g_nullRenderBackend;
+    }
+}
+
+IRenderBackend& GetRenderBackend()
+{
+    return *g_activeRenderBackend;
+}
+

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DDisplay.cpp
@@ -79,6 +79,7 @@ static void drawFramerateBar(void);
 #include "W3DDevice/GameClient/W3DShaderManager.h"
 #include "W3DDevice/GameClient/W3DDebugDisplay.h"
 #include "W3DDevice/GameClient/W3DProjectedShadow.h"
+#include "WW3D2/dx8wrapper.h"
 #include "W3DDevice/GameClient/W3DShroud.h"
 #include "WWMath/WWMath.h"
 #include "WWLib/Registry.h"
@@ -93,6 +94,7 @@ static void drawFramerateBar(void);
 #include "WW3D2/SortingRenderer.h"
 #include "WW3D2/Textureloader.h"
 #include "WW3D2/DX8WebBrowser.h"
+#include "W3DDevice/GameClient/RenderBackend.h"
 #include "WW3D2/Mesh.h"
 #include "WW3D2/HLOD.h"
 #include "WW3D2/Meshmatdesc.h"
@@ -466,6 +468,8 @@ W3DDisplay::~W3DDisplay()
 	delete TheW3DFileSystem;
 	TheW3DFileSystem = NULL;
 
+	SetRenderBackend(NULL);
+
 }  // end ~W3DDisplay
 
 #define MIN_DISPLAY_RESOLUTION_X	800
@@ -548,36 +552,49 @@ void W3DDisplay::setGamma(Real gamma, Real bright, Real contrast, Bool calibrate
 	DX8Wrapper::Set_Gamma(gamma,bright,contrast,calibrate, false);
 }
 
-/*Giant hack in order to keep the game from getting stuck when alt-tabbing*/
-void Reset_D3D_Device(bool active)
+class Dx8RenderBackend : public IRenderBackend
 {
-	if (TheDisplay && WW3D::Is_Initted() && !TheDisplay->getWindowed())
-	{
-		if (active)
-		{	
-			//switch back to desired mode when user alt-tabs back into game
-			WW3D::Set_Render_Device( WW3D::Get_Render_Device(),TheDisplay->getWidth(),TheDisplay->getHeight(),TheDisplay->getBitDepth(),TheDisplay->getWindowed(),true, true);
-			OSVERSIONINFO	osvi;
-			osvi.dwOSVersionInfoSize=sizeof(OSVERSIONINFO);
-			if (GetVersionEx(&osvi))
-			{	//check if we're running Win9x variant since they have buggy alt-tab that requires
-				//reloading all textures.
-				if (osvi.dwPlatformId == VER_PLATFORM_WIN32_WINDOWS)
-				{	//only do this on Win9x boxes because it makes alt-tab very slow.
+public:
+        virtual void HandleFocusChange(bool isActive)
+        {
+		if (TheDisplay && WW3D::Is_Initted() && !TheDisplay->getWindowed())
+		{
+			if (isActive)
+			{
+				WW3D::Set_Render_Device(WW3D::Get_Render_Device(), TheDisplay->getWidth(), TheDisplay->getHeight(),
+					TheDisplay->getBitDepth(), TheDisplay->getWindowed(), true, true);
+				OSVERSIONINFO osvi;
+				osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+				if (GetVersionEx(&osvi))
+				{
+					if (osvi.dwPlatformId == VER_PLATFORM_WIN32_WINDOWS)
+					{
 						WW3D::_Invalidate_Textures();
+					}
 				}
 			}
-		}
-		else
-		{
-			//switch to windowed mode whenever the user alt-tabs out of game. Don't restore assets after reset since we'll do it when returning.
-			WW3D::Set_Render_Device( WW3D::Get_Render_Device(),TheDisplay->getWidth(),TheDisplay->getHeight(),TheDisplay->getBitDepth(),TheDisplay->getWindowed(),true, true, false);
+			else
+			{
+				WW3D::Set_Render_Device(WW3D::Get_Render_Device(), TheDisplay->getWidth(), TheDisplay->getHeight(),
+					TheDisplay->getBitDepth(), TheDisplay->getWindowed(), true, true, false);
+			}
 		}
 	}
-}
+};
 
-/** Set resolution of display */
-//=============================================================================
+static Dx8RenderBackend g_dx8RenderBackend;
+
+class BgfxRenderBackend : public IRenderBackend
+{
+public:
+        virtual void HandleFocusChange(bool)
+        {
+                // No focus handling is required for the bgfx backend yet.
+        }
+};
+
+static BgfxRenderBackend g_bgfxRenderBackend;
+
 Bool W3DDisplay::setDisplayMode( UnsignedInt xres, UnsignedInt yres, UnsignedInt bitdepth, Bool windowed )
 {
 	if (WW3D_ERROR_OK == WW3D::Set_Device_Resolution(xres,yres,bitdepth,windowed,true))
@@ -730,6 +747,16 @@ void W3DDisplay::init( void )
 	{
 		SortingRendererClass::SetMinVertexBufferSize(1);
 	}
+	DX8Wrapper::Set_Active_Backend(ApplicationGraphicsBackend);
+	if (ApplicationGraphicsBackend == GRAPHICS_BACKEND_BGFX)
+	{
+		SetRenderBackend(&g_bgfxRenderBackend);
+	}
+	else
+	{
+		SetRenderBackend(&g_dx8RenderBackend);
+	}
+
 	if (WW3D::Init( ApplicationHWnd ) != WW3D_ERROR_OK)
 		throw ERROR_INVALID_D3D;	//failed to initialize.  User probably doesn't have DX 8.1
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8indexbuffer.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8indexbuffer.cpp
@@ -45,7 +45,41 @@
 #include "thread.h"
 #include "wwmemlog.h"
 
+#if __has_include(<bgfx/bgfx.h>)
+#define WW3D_BGFX_INDEX_AVAILABLE 1
+#include <bgfx/bgfx.h>
+#include <vector>
+#else
+#define WW3D_BGFX_INDEX_AVAILABLE 0
+#endif
+
 #define DEFAULT_IB_SIZE 5000
+
+#if WW3D_BGFX_INDEX_AVAILABLE
+struct DX8IndexBufferBgfxData
+{
+	DX8IndexBufferBgfxData(bool is_dynamic, unsigned int index_count)
+		: dynamic(is_dynamic),
+		  lock_active(false),
+		  index_count(index_count),
+		  lock_offset(0),
+		  lock_size(0),
+		  data(index_count)
+	{
+		dynamic_handle.idx = bgfx::kInvalidHandle;
+		static_handle.idx = bgfx::kInvalidHandle;
+	}
+
+	bool dynamic;
+	bool lock_active;
+	unsigned int index_count;
+	unsigned int lock_offset;
+	unsigned int lock_size;
+	std::vector<unsigned short> data;
+	bgfx::DynamicIndexBufferHandle dynamic_handle;
+	bgfx::IndexBufferHandle static_handle;
+};
+#endif
 
 static bool _DynamicSortingIndexArrayInUse=false;
 static SortingIndexBufferClass* _DynamicSortingIndexArray;
@@ -191,11 +225,10 @@ IndexBufferClass::WriteLockClass::WriteLockClass(IndexBufferClass* index_buffer_
 	switch (index_buffer->Type()) {
 	case BUFFER_TYPE_DX8:
 		DX8_Assert();
-		DX8_ErrorCode(static_cast<DX8IndexBufferClass*>(index_buffer)->Get_DX8_Index_Buffer()->Lock(
+		indices = static_cast<DX8IndexBufferClass*>(index_buffer)->Lock(
 			0,
 			index_buffer->Get_Index_Count()*sizeof(WORD),
-			(unsigned char**)&indices,
-			flags));
+			flags);
 		break;
 	case BUFFER_TYPE_SORTING:
 		indices=static_cast<SortingIndexBufferClass*>(index_buffer)->index_buffer;
@@ -217,7 +250,7 @@ IndexBufferClass::WriteLockClass::~WriteLockClass()
 	switch (index_buffer->Type()) {
 	case BUFFER_TYPE_DX8:
 		DX8_Assert();
-		DX8_ErrorCode(static_cast<DX8IndexBufferClass*>(index_buffer)->index_buffer->Unlock());
+		static_cast<DX8IndexBufferClass*>(index_buffer)->Unlock();
 		break;
 	case BUFFER_TYPE_SORTING:
 		break;
@@ -242,11 +275,10 @@ IndexBufferClass::AppendLockClass::AppendLockClass(IndexBufferClass* index_buffe
 	switch (index_buffer->Type()) {
 	case BUFFER_TYPE_DX8:
 		DX8_Assert();
-		DX8_ErrorCode(static_cast<DX8IndexBufferClass*>(index_buffer)->index_buffer->Lock(
+		indices = static_cast<DX8IndexBufferClass*>(index_buffer)->Lock(
 			start_index*sizeof(unsigned short),
 			index_range*sizeof(unsigned short),
-			(unsigned char**)&indices,
-			0));
+			0);
 		break;
 	case BUFFER_TYPE_SORTING:
 		indices=static_cast<SortingIndexBufferClass*>(index_buffer)->index_buffer+start_index;
@@ -265,7 +297,7 @@ IndexBufferClass::AppendLockClass::~AppendLockClass()
 	switch (index_buffer->Type()) {
 	case BUFFER_TYPE_DX8:
 		DX8_Assert();
-		DX8_ErrorCode(static_cast<DX8IndexBufferClass*>(index_buffer)->index_buffer->Unlock());
+		static_cast<DX8IndexBufferClass*>(index_buffer)->Unlock();
 		break;
 	case BUFFER_TYPE_SORTING:
 		break;
@@ -283,56 +315,205 @@ IndexBufferClass::AppendLockClass::~AppendLockClass()
 // ----------------------------------------------------------------------------
 
 DX8IndexBufferClass::DX8IndexBufferClass(unsigned short index_count_,UsageType usage)
-	:
-	IndexBufferClass(BUFFER_TYPE_DX8,index_count_)
+        :
+        IndexBufferClass(BUFFER_TYPE_DX8,index_count_),
+        index_buffer(NULL),
+        m_bgfxData(NULL)
 {
-	DX8_THREAD_ASSERT();
-	WWASSERT(index_count);
-	unsigned usage_flags=
-		D3DUSAGE_WRITEONLY|
-		((usage&USAGE_DYNAMIC) ? D3DUSAGE_DYNAMIC : 0)|
-		((usage&USAGE_NPATCHES) ? D3DUSAGE_NPATCHES : 0)|
-		((usage&USAGE_SOFTWAREPROCESSING) ? D3DUSAGE_SOFTWAREPROCESSING : 0);
-	if (!DX8Wrapper::Get_Current_Caps()->Support_TnL()) {
-		usage_flags|=D3DUSAGE_SOFTWAREPROCESSING;
-	}
+        DX8_THREAD_ASSERT();
+        WWASSERT(index_count);
 
-	HRESULT ret=DX8Wrapper::_Get_D3D_Device8()->CreateIndexBuffer(
-		sizeof(WORD)*index_count,
-		usage_flags,
-		D3DFMT_INDEX16,
-		(usage&USAGE_DYNAMIC) ? D3DPOOL_DEFAULT : D3DPOOL_MANAGED,
-		&index_buffer);
+#if WW3D_BGFX_INDEX_AVAILABLE
+        if (DX8Wrapper::Is_Bgfx_Active())
+        {
+                m_bgfxData = W3DNEW DX8IndexBufferBgfxData((usage & USAGE_DYNAMIC) != 0, index_count);
+                if (m_bgfxData->dynamic)
+                {
+                        m_bgfxData->dynamic_handle = bgfx::createDynamicIndexBuffer(index_count);
+                }
+                return;
+        }
+#endif
 
-	if (SUCCEEDED(ret)) {
-		return;
-	}
+        unsigned usage_flags=
+                D3DUSAGE_WRITEONLY|
+                ((usage&USAGE_DYNAMIC) ? D3DUSAGE_DYNAMIC : 0)|
+                ((usage&USAGE_NPATCHES) ? D3DUSAGE_NPATCHES : 0)|
+                ((usage&USAGE_SOFTWAREPROCESSING) ? D3DUSAGE_SOFTWAREPROCESSING : 0);
+        if (!DX8Wrapper::Get_Current_Caps()->Support_TnL()) {
+                usage_flags|=D3DUSAGE_SOFTWAREPROCESSING;
+        }
 
-	WWDEBUG_SAY(("Index buffer creation failed, trying to release assets...\n"));
+        HRESULT ret=DX8Wrapper::_Get_D3D_Device8()->CreateIndexBuffer(
+                sizeof(WORD)*index_count,
+                usage_flags,
+                D3DFMT_INDEX16,
+                (usage&USAGE_DYNAMIC) ? D3DPOOL_DEFAULT : D3DPOOL_MANAGED,
+                &index_buffer);
 
-	// Vertex buffer creation failed, so try releasing least used textures and flushing the mesh cache.
+        if (SUCCEEDED(ret)) {
+                return;
+        }
 
-	// Free all textures that haven't been used in the last 5 seconds
-	TextureClass::Invalidate_Old_Unused_Textures(5000);
+        WWDEBUG_SAY(("Index buffer creation failed, trying to release assets...
+"));
 
-	// Invalidate the mesh cache
-	WW3D::_Invalidate_Mesh_Cache();
+        // Vertex buffer creation failed, so try releasing least used textures and flushing the mesh cache.
 
-	// Try again...
-	ret=DX8Wrapper::_Get_D3D_Device8()->CreateIndexBuffer(
-		sizeof(WORD)*index_count,
-		usage_flags,
-		D3DFMT_INDEX16,
-		(usage&USAGE_DYNAMIC) ? D3DPOOL_DEFAULT : D3DPOOL_MANAGED,
-		&index_buffer);
+        // Free all textures that haven't been used in the last 5 seconds
+        TextureClass::Invalidate_Old_Unused_Textures(5000);
 
-	if (SUCCEEDED(ret)) {
-		WWDEBUG_SAY(("...Index buffer creation succesful\n"));
-	}
+        // Invalidate the mesh cache
+        WW3D::_Invalidate_Mesh_Cache();
 
-	// If it still fails it is fatal
-	DX8_ErrorCode(ret);
+        // Try again...
+        ret=DX8Wrapper::_Get_D3D_Device8()->CreateIndexBuffer(
+                sizeof(WORD)*index_count,
+                usage_flags,
+                D3DFMT_INDEX16,
+                (usage&USAGE_DYNAMIC) ? D3DPOOL_DEFAULT : D3DPOOL_MANAGED,
+                &index_buffer);
+
+        if (SUCCEEDED(ret)) {
+                WWDEBUG_SAY(("...Index buffer creation succesful
+"));
+        }
+
+        // If it still fails it is fatal
+        DX8_ErrorCode(ret);
 }
+
+// ----------------------------------------------------------------------------
+
+DX8IndexBufferClass::~DX8IndexBufferClass()
+{
+#if WW3D_BGFX_INDEX_AVAILABLE
+        if (m_bgfxData)
+        {
+                if (m_bgfxData->dynamic)
+                {
+                        if (bgfx::isValid(m_bgfxData->dynamic_handle))
+                        {
+                                bgfx::destroy(m_bgfxData->dynamic_handle);
+                        }
+                }
+                else if (bgfx::isValid(m_bgfxData->static_handle))
+                {
+                        bgfx::destroy(m_bgfxData->static_handle);
+                }
+                delete m_bgfxData;
+                m_bgfxData = NULL;
+        }
+#endif
+        if (index_buffer)
+        {
+                index_buffer->Release();
+                index_buffer = NULL;
+        }
+}
+
+// ----------------------------------------------------------------------------
+
+unsigned short* DX8IndexBufferClass::Lock(unsigned offset_bytes, unsigned size_bytes, unsigned flags)
+{
+#if WW3D_BGFX_INDEX_AVAILABLE
+        (void)flags;
+        if (m_bgfxData)
+        {
+                const unsigned int total_indices = m_bgfxData->index_count;
+                const unsigned int total_bytes = total_indices * sizeof(unsigned short);
+                if (offset_bytes >= total_bytes)
+                {
+                        m_bgfxData->lock_offset = total_indices;
+                        m_bgfxData->lock_size = 0;
+                        m_bgfxData->lock_active = true;
+                        return m_bgfxData->data.data() + total_indices;
+                }
+
+                unsigned int range_bytes = size_bytes;
+                if (!range_bytes || (offset_bytes + range_bytes) > total_bytes)
+                {
+                        range_bytes = total_bytes - offset_bytes;
+                }
+
+                WWASSERT((offset_bytes % sizeof(unsigned short)) == 0);
+                WWASSERT((range_bytes % sizeof(unsigned short)) == 0);
+
+                const unsigned int offset_indices = offset_bytes / sizeof(unsigned short);
+                const unsigned int count = range_bytes / sizeof(unsigned short);
+
+                m_bgfxData->lock_offset = offset_indices;
+                m_bgfxData->lock_size = count;
+                m_bgfxData->lock_active = true;
+
+                return m_bgfxData->data.data() + offset_indices;
+        }
+#endif
+
+        unsigned short* indices = NULL;
+        if (index_buffer)
+        {
+                DX8_ErrorCode(index_buffer->Lock(offset_bytes, size_bytes, reinterpret_cast<unsigned char**>(&indices), flags));
+        }
+        return indices;
+}
+
+// ----------------------------------------------------------------------------
+
+void DX8IndexBufferClass::Unlock()
+{
+#if WW3D_BGFX_INDEX_AVAILABLE
+        if (m_bgfxData)
+        {
+                if (m_bgfxData->lock_active)
+                {
+                        const unsigned int total_indices = m_bgfxData->index_count;
+                        unsigned int offset = m_bgfxData->lock_offset;
+                        unsigned int count = m_bgfxData->lock_size;
+                        if (!count && offset < total_indices)
+                        {
+                                count = total_indices - offset;
+                        }
+                        if (count && offset < total_indices)
+                        {
+                                if (m_bgfxData->dynamic)
+                                {
+                                        if (!bgfx::isValid(m_bgfxData->dynamic_handle))
+                                        {
+                                                m_bgfxData->dynamic_handle = bgfx::createDynamicIndexBuffer(total_indices);
+                                        }
+                                        if (bgfx::isValid(m_bgfxData->dynamic_handle))
+                                        {
+                                                const bgfx::Memory* memory = bgfx::copy(reinterpret_cast<const unsigned char*>(m_bgfxData->data.data() + offset), count * sizeof(unsigned short));
+                                                bgfx::update(m_bgfxData->dynamic_handle, offset, memory);
+                                        }
+                                }
+                                else
+                                {
+                                        const bgfx::Memory* memory = bgfx::copy(reinterpret_cast<const unsigned char*>(m_bgfxData->data.data()), total_indices * sizeof(unsigned short));
+                                        if (bgfx::isValid(m_bgfxData->static_handle))
+                                        {
+                                                bgfx::destroy(m_bgfxData->static_handle);
+                                        }
+                                        m_bgfxData->static_handle = bgfx::createIndexBuffer(memory);
+                                }
+                        }
+
+                        m_bgfxData->lock_active = false;
+                        m_bgfxData->lock_offset = 0;
+                        m_bgfxData->lock_size = 0;
+                }
+                return;
+        }
+#endif
+
+        if (index_buffer)
+        {
+                DX8_ErrorCode(index_buffer->Unlock());
+        }
+}
+
+// ----------------------------------------------------------------------------
 
 // ----------------------------------------------------------------------------
 
@@ -430,12 +611,10 @@ DynamicIBAccessClass::WriteLockClass::WriteLockClass(DynamicIBAccessClass* ib_ac
 		WWASSERT(DynamicIBAccess);
 //		WWASSERT(!dynamic_dx8_index_buffer->Engine_Refs());
 		DX8_Assert();
-		DX8_ErrorCode(
-			static_cast<DX8IndexBufferClass*>(DynamicIBAccess->IndexBuffer)->Get_DX8_Index_Buffer()->Lock(
+		Indices = static_cast<DX8IndexBufferClass*>(DynamicIBAccess->IndexBuffer)->Lock(
 			DynamicIBAccess->IndexBufferOffset*sizeof(WORD),
 			DynamicIBAccess->Get_Index_Count()*sizeof(WORD),
-			(unsigned char**)&Indices,
-			!DynamicIBAccess->IndexBufferOffset ? D3DLOCK_DISCARD : D3DLOCK_NOOVERWRITE));
+			!DynamicIBAccess->IndexBufferOffset ? D3DLOCK_DISCARD : D3DLOCK_NOOVERWRITE);
 		break;
 	case BUFFER_TYPE_DYNAMIC_SORTING:
 		Indices=static_cast<SortingIndexBufferClass*>(DynamicIBAccess->IndexBuffer)->index_buffer;
@@ -453,7 +632,7 @@ DynamicIBAccessClass::WriteLockClass::~WriteLockClass()
 	switch (DynamicIBAccess->Get_Type()) {
 	case BUFFER_TYPE_DYNAMIC_DX8:
 		DX8_Assert();
-		DX8_ErrorCode(static_cast<DX8IndexBufferClass*>(DynamicIBAccess->IndexBuffer)->Get_DX8_Index_Buffer()->Unlock());
+		static_cast<DX8IndexBufferClass*>(DynamicIBAccess->IndexBuffer)->Unlock();
 		break;
 	case BUFFER_TYPE_DYNAMIC_SORTING:
 		break;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8indexbuffer.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8indexbuffer.h
@@ -52,6 +52,7 @@ class DX8Wrapper;
 class SortingRendererClass;
 struct IDirect3DIndexBuffer8;
 class DX8IndexBufferClass;
+struct DX8IndexBufferBgfxData;
 class SortingIndexBufferClass;
 
 // ----------------------------------------------------------------------------
@@ -181,8 +182,12 @@ public:
 
 	inline IDirect3DIndexBuffer8* Get_DX8_Index_Buffer()	{ return index_buffer; }
 	
+	unsigned short* Lock(unsigned offset_bytes, unsigned size_bytes, unsigned flags);
+	void Unlock();
+
 private:
 	IDirect3DIndexBuffer8*	index_buffer;		// actual dx8 index buffer
+	DX8IndexBufferBgfxData* m_bgfxData;
 };
 
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8vertexbuffer.h
@@ -62,6 +62,7 @@ class FVFInfoClass;
 struct IDirect3DVertexBuffer8;
 class VertexBufferClass;
 struct VertexFormatXYZNDUV2;
+struct DX8VertexBufferBgfxData;
 
 class VertexBufferLockClass
 {
@@ -225,6 +226,9 @@ public:
 
 	IDirect3DVertexBuffer8* Get_DX8_Vertex_Buffer() { return VertexBuffer; }
 
+	void* Lock(unsigned offset_bytes, unsigned size_bytes, unsigned flags);
+	void Unlock();
+
 	void Copy(const Vector3* loc, unsigned first_vertex, unsigned count);
 	void Copy(const Vector3* loc, const Vector2* uv, unsigned first_vertex, unsigned count);
 	void Copy(const Vector3* loc, const Vector3* norm, unsigned first_vertex, unsigned count);
@@ -234,6 +238,7 @@ public:
 
 protected:
 	IDirect3DVertexBuffer8*		VertexBuffer;
+	DX8VertexBufferBgfxData*		m_bgfxData;
 
 	void Create_Vertex_Buffer(UsageType usage);
 };

--- a/GeneralsMD/Code/Main/GraphicsBackend.h
+++ b/GeneralsMD/Code/Main/GraphicsBackend.h
@@ -1,0 +1,42 @@
+/*
+**      Command & Conquer Generals(tm)
+**      Copyright 2025 Electronic Arts Inc.
+**
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
+**
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
+**
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+//
+//  (c) 2001-2003 Electronic Arts Inc.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// FILE: GraphicsBackend.h //////////////////////////////////////////////////////
+//
+// Enumeration describing the available rendering backends.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef MAIN_GRAPHICSBACKEND_H
+#define MAIN_GRAPHICSBACKEND_H
+
+enum GraphicsBackend
+{
+        GRAPHICS_BACKEND_DIRECT3D8 = 0,
+        GRAPHICS_BACKEND_OPENGL,
+        GRAPHICS_BACKEND_BGFX,
+};
+
+#endif  // MAIN_GRAPHICSBACKEND_H
+

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -66,6 +66,7 @@
 #include "GameClient/IMEManager.h"
 #include "Win32Device/GameClient/Win32Mouse.h"
 #include "Win32Device/Common/Win32GameEngine.h"
+#include "W3DDevice/GameClient/RenderBackend.h"
 #include "Common/Version.h"
 #include "BuildVersion.h"
 #include "GeneratedVersion.h"
@@ -97,8 +98,6 @@ static HANDLE GeneralsMutex = NULL;
 #define GENERALS_GUID "685EAFF2-3216-4265-B047-251C5F4B82F3"
 #define DEFAULT_XRESOLUTION 800
 #define DEFAULT_YRESOLUTION 600
-
-extern void Reset_D3D_Device(bool active);
 
 static Bool gInitializing = false;
 static Bool gDoPaint = true;
@@ -572,7 +571,7 @@ LRESULT CALLBACK WndProc( HWND hWnd, UINT message,
 					if (TheGameEngine)
 						TheGameEngine->setIsActive(isWinMainActive);
 
-					Reset_D3D_Device(isWinMainActive);
+					GetRenderBackend().HandleFocusChange(isWinMainActive != FALSE);
 					if (isWinMainActive)
 					{	//restore mouse cursor to our custom version.
 						if (TheWin32Mouse)

--- a/GeneralsMD/Code/Main/WinMain.h
+++ b/GeneralsMD/Code/Main/WinMain.h
@@ -37,6 +37,7 @@
 #include <windows.h>
 
 // USER INCLUDES //////////////////////////////////////////////////////////////
+#include "GraphicsBackend.h"
 #include "Win32Device/GameClient/Win32Mouse.h"
 
 // EXTERNAL ///////////////////////////////////////////////////////////////////
@@ -44,12 +45,6 @@ extern HINSTANCE ApplicationHInstance;  ///< our application instance
 extern HWND ApplicationHWnd;  ///< our application window handle
 extern HDC ApplicationHDC;  ///< device context for the primary window (OpenGL)
 extern HGLRC ApplicationHGLRC; ///< OpenGL rendering context
-
-enum GraphicsBackend
-{
-        GRAPHICS_BACKEND_DIRECT3D8 = 0,
-        GRAPHICS_BACKEND_OPENGL
-};
 
 extern GraphicsBackend ApplicationGraphicsBackend; ///< active rendering backend
 extern Win32Mouse *TheWin32Mouse;  ///< global for win32 mouse only!


### PR DESCRIPTION
## Summary
- add bgfx-backed index buffer state management and lock/unlock routines to the Generals WW3D index buffer implementation so data uploads can flow through bgfx handles instead of direct D3D locks
- expose the new lock/unlock helpers on DX8IndexBufferClass and update the write/append and dynamic access paths to invoke them, ensuring the staging logic works for bgfx
- mirror the same bgfx-capable index buffer implementation in the Zero Hour codebase

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cac7c33acc8331aed5de9b74428b5f