### PR TITLE
Allow surfaces to share bgfx render targets

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8texman.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8texman.cpp
@@ -188,8 +188,8 @@ void DX8TextureManagerClass::Recreate_Textures()
 	{
 		DX8TextureTrackerClass *track=it.Peek_Obj();
 		WWASSERT(track->Texture->D3DTexture==NULL);
-		track->Texture->D3DTexture=DX8Wrapper::_Create_DX8_Texture(track->Width,track->Height,
-			track->Format,track->Mip_level_count,D3DPOOL_DEFAULT,track->RenderTarget);
+                track->Texture->D3DTexture=DX8Wrapper::_Create_DX8_Texture(track->Width,track->Height,
+                        track->Format,track->Mip_level_count,D3DPOOL_DEFAULT,track->RenderTarget,track->Texture);
 		track->Texture->Dirty=true;
 		it.Next();
 	}

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -368,18 +368,19 @@ public:
 	/*
 	** Resources
 	*/
-	static IDirect3DTexture8 * _Create_DX8_Texture(
-		unsigned int width, 
-		unsigned int height, 
-		WW3DFormat format, 
-		TextureClass::MipCountType mip_level_count,
-		D3DPOOL pool=D3DPOOL_MANAGED,
-		bool rendertarget=false);
-	static IDirect3DTexture8 * _Create_DX8_Texture(const char *filename, TextureClass::MipCountType mip_level_count);
-	static IDirect3DTexture8 * _Create_DX8_Texture(IDirect3DSurface8 *surface, TextureClass::MipCountType mip_level_count);
+        static IDirect3DTexture8 * _Create_DX8_Texture(
+                unsigned int width,
+                unsigned int height,
+                WW3DFormat format,
+                TextureClass::MipCountType mip_level_count,
+                D3DPOOL pool=D3DPOOL_MANAGED,
+                bool rendertarget=false,
+                TextureClass* texture_owner=NULL);
+        static IDirect3DTexture8 * _Create_DX8_Texture(const char *filename, TextureClass::MipCountType mip_level_count, TextureClass* texture_owner=NULL);
+        static IDirect3DTexture8 * _Create_DX8_Texture(IDirect3DSurface8 *surface, TextureClass::MipCountType mip_level_count, TextureClass* texture_owner=NULL);
 
-	static IDirect3DSurface8 * _Create_DX8_Surface(unsigned int width, unsigned int height, WW3DFormat format);
-	static IDirect3DSurface8 * _Create_DX8_Surface(const char *filename);
+        static IDirect3DSurface8 * _Create_DX8_Surface(unsigned int width, unsigned int height, WW3DFormat format, SurfaceClass* surface_owner=NULL);
+        static IDirect3DSurface8 * _Create_DX8_Surface(const char *filename, SurfaceClass* surface_owner=NULL);
 	static IDirect3DSurface8 * _Get_DX8_Front_Buffer();
 	static SurfaceClass * _Get_DX8_Back_Buffer(unsigned int num=0);
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/surfaceclass.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/surfaceclass.h
@@ -46,9 +46,21 @@
 #include "ww3dformat.h"
 #include "refcount.h"
 
+#ifndef WW3D_BGFX_AVAILABLE
+#define WW3D_BGFX_AVAILABLE 0
+#endif
+
+#if WW3D_BGFX_AVAILABLE
+#include <bgfx/bgfx.h>
+#endif
+
 struct IDirect3DSurface8;
 class Vector2i;
 class Vector3;
+
+#if WW3D_BGFX_AVAILABLE
+class TextureClass;
+#endif
 
 /*************************************************************************
 **                             SurfaceClass
@@ -140,13 +152,44 @@ class SurfaceClass : public W3DMPO, public RefCountClass
 
 		WW3DFormat Get_Surface_Format() const { return SurfaceFormat; }
 
-	private:
+        private:
 
-		// Direct3D surface object
-		IDirect3DSurface8 *D3DSurface;
+                // Direct3D surface object
+                IDirect3DSurface8 *D3DSurface;
 
-		WW3DFormat SurfaceFormat;
-	friend class TextureClass;	
+                WW3DFormat SurfaceFormat;
+        friend class TextureClass;
+
+#if WW3D_BGFX_AVAILABLE
+        public:
+                bool Has_Bgfx_Surface() const;
+                bgfx::TextureHandle Get_Bgfx_Texture_Handle() const;
+                bgfx::FrameBufferHandle Get_Bgfx_Frame_Buffer_Handle() const;
+
+        private:
+                struct BgfxSurfaceInfo
+                {
+                        BgfxSurfaceInfo();
+                        void Reset();
+
+                        bgfx::TextureHandle texture;
+                        bgfx::FrameBufferHandle framebuffer;
+                        TextureClass* ownerTexture;
+                        unsigned int ownerMipLevel;
+                        uint16_t width;
+                        uint16_t height;
+                        WW3DFormat format;
+                        bool renderTarget;
+                        bool ownsHandles;
+                };
+
+                void Destroy_Bgfx_Surface();
+                void Create_Bgfx_Surface(uint16_t width, uint16_t height, WW3DFormat format, bool render_target);
+                void Create_Bgfx_Surface_From_D3D(IDirect3DSurface8* surface);
+                void Create_Bgfx_Surface_From_Texture(TextureClass* texture, unsigned int level);
+
+                BgfxSurfaceInfo m_bgfxData;
+#endif
 };
 
 #endif

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/texture.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/texture.h
@@ -49,6 +49,14 @@
 #include "ww3dformat.h"
 #include "wwstring.h"
 
+#ifndef WW3D_BGFX_AVAILABLE
+#define WW3D_BGFX_AVAILABLE 0
+#endif
+
+#if WW3D_BGFX_AVAILABLE
+#include <bgfx/bgfx.h>
+#endif
+
 class DX8Wrapper;
 struct IDirect3DTexture8;
 class TextureLoader;
@@ -223,6 +231,29 @@ class TextureClass : public W3DMPO, public RefCountClass
 		// Apply a Null texture's settings into D3D
 		static void Apply_Null(unsigned int stage);
 
+#if WW3D_BGFX_AVAILABLE
+		struct BgfxTextureInfo
+		{
+			BgfxTextureInfo();
+
+			void Reset();
+
+			bgfx::TextureHandle                 texture;
+			bgfx::FrameBufferHandle             framebuffer;
+			uint16_t                                        width;
+			uint16_t                                        height;
+			uint8_t                                         mipCount;
+			bool                                                    renderTarget;
+			uint64_t                                                flags;
+		};
+
+		void Destroy_Bgfx_Resources();
+		void Upload_Bgfx_Texture(uint16_t width, uint16_t height, WW3DFormat format, uint8_t mip_count, bool render_target, const uint8_t* const* data, const uint32_t* pitches);
+		void Create_Bgfx_Texture_From_D3D(IDirect3DTexture8* texture, WW3DFormat format, bool render_target);
+		void Create_Bgfx_Texture_From_Locked_Task(TextureLoadTaskClass* task);
+		BgfxTextureInfo m_bgfxData;
+#endif
+
 		// State not contained in the Direct3D texture object:
 		FilterType TextureMinFilter;
 		FilterType TextureMagFilter;
@@ -264,6 +295,13 @@ public:
 		TextureLoadTaskClass* TextureLoadTask;
 		// Background texture loader will call this when texture has been loaded
 		void Apply_New_Surface(bool initialized);	// If the parameter is true, the texture will be flagged as initialised
+
+#if WW3D_BGFX_AVAILABLE
+public:
+		bool Has_Bgfx_Texture() const;
+		bgfx::TextureHandle Get_Bgfx_Texture_Handle() const;
+		bgfx::FrameBufferHandle Get_Bgfx_Frame_Buffer_Handle() const;
+#endif
 
 };
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
@@ -1242,6 +1242,12 @@ void TextureLoadTaskClass::Begin_Thumbnail_Load()
 
 void TextureLoadTaskClass::End_Load()
 {
+#if WW3D_BGFX_AVAILABLE
+	if (DX8Wrapper::Is_Bgfx_Active() && !HasFailed && Texture)
+	{
+		Texture->Create_Bgfx_Texture_From_Locked_Task(this);
+	}
+#endif
 	for (unsigned i=0;i<MipLevelCount;++i) {
 		if (LockedSurfacePtr[i]) {
 			WWASSERT(ThreadClass::_Get_Current_Thread_ID()==DX8Wrapper::_Get_Main_Thread_ID());

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/textureloader.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/textureloader.h
@@ -101,6 +101,7 @@ class TextureLoadTaskClass : public W3DMPO
 
 	~TextureLoadTaskClass();
 	TextureLoadTaskClass();
+	friend class TextureClass;
 public:
 	static TextureLoadTaskClass* Get_Instance(TextureClass* tc, bool high_priority);
 	static void Release_Instance(TextureLoadTaskClass* task);


### PR DESCRIPTION
## Summary
- let SurfaceClass keep track of borrowed bgfx handles so texture-backed render targets share the same framebuffer
- expose texture-backed bgfx handles when fetching a surface level to ensure render-to-texture paths use bgfx resources directly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb1ccf9f8c8331b6590f83dd9f3a4b