### PR TITLE
Add bgfx texture and surface integration

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/surfaceclass.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/surfaceclass.h
@@ -52,6 +52,7 @@
 
 #if WW3D_BGFX_AVAILABLE
 #include <bgfx/bgfx.h>
+#include <vector>
 #endif
 
 struct IDirect3DSurface8;
@@ -72,8 +73,8 @@ class TextureClass;
 *************************************************************************/
 class SurfaceClass : public W3DMPO, public RefCountClass
 {
-	W3DMPO_GLUE(SurfaceClass)
-	public:
+        W3DMPO_GLUE(SurfaceClass)
+        public:
 
 		struct SurfaceDescription {
 			WW3DFormat		Format;	// Surface format
@@ -88,12 +89,16 @@ class SurfaceClass : public W3DMPO, public RefCountClass
 		SurfaceClass(const char *filename);
 
 		// Create the surface from a D3D pointer
-		SurfaceClass(IDirect3DSurface8 *d3d_surface);
+                SurfaceClass(IDirect3DSurface8 *d3d_surface);
 
-		~SurfaceClass(void);
+                ~SurfaceClass(void);
 
-		// Get surface description
-		 void Get_Description(SurfaceDescription &surface_desc);
+#if WW3D_BGFX_AVAILABLE
+                static SurfaceClass* Create_From_Bgfx_Texture(TextureClass* texture, unsigned int level);
+#endif
+
+                // Get surface description
+                 void Get_Description(SurfaceDescription &surface_desc);
 
 		// Lock / unlock the surface
 		void * Lock(int * pitch);
@@ -181,6 +186,8 @@ class SurfaceClass : public W3DMPO, public RefCountClass
                         WW3DFormat format;
                         bool renderTarget;
                         bool ownsHandles;
+                        std::vector<uint8_t> stagingData;
+                        uint32_t stagingPitch;
                 };
 
                 void Destroy_Bgfx_Surface();
@@ -189,6 +196,12 @@ class SurfaceClass : public W3DMPO, public RefCountClass
                 void Create_Bgfx_Surface_From_Texture(TextureClass* texture, unsigned int level);
 
                 BgfxSurfaceInfo m_bgfxData;
+#endif
+
+#if WW3D_BGFX_AVAILABLE
+        private:
+                struct BgfxEmptyTag {};
+                explicit SurfaceClass(BgfxEmptyTag);
 #endif
 };
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/texture.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/texture.h
@@ -232,20 +232,21 @@ class TextureClass : public W3DMPO, public RefCountClass
 		static void Apply_Null(unsigned int stage);
 
 #if WW3D_BGFX_AVAILABLE
-		struct BgfxTextureInfo
-		{
-			BgfxTextureInfo();
+                struct BgfxTextureInfo
+                {
+                        BgfxTextureInfo();
 
-			void Reset();
+                        void Reset();
 
-			bgfx::TextureHandle                 texture;
-			bgfx::FrameBufferHandle             framebuffer;
-			uint16_t                                        width;
-			uint16_t                                        height;
-			uint8_t                                         mipCount;
-			bool                                                    renderTarget;
-			uint64_t                                                flags;
-		};
+                        bgfx::TextureHandle                 texture;
+                        bgfx::FrameBufferHandle             framebuffer;
+                        uint16_t                                        width;
+                        uint16_t                                        height;
+                        uint8_t                                         mipCount;
+                        WW3DFormat                                     format;
+                        bool                                                    renderTarget;
+                        uint64_t                                                flags;
+                };
 
 		void Destroy_Bgfx_Resources();
 		void Upload_Bgfx_Texture(uint16_t width, uint16_t height, WW3DFormat format, uint8_t mip_count, bool render_target, const uint8_t* const* data, const uint32_t* pitches);


### PR DESCRIPTION
## Summary
- track bgfx texture metadata so mip queries and memory accounting work without Direct3D handles
- allow SurfaceClass to wrap bgfx textures and provide lock/unlock behavior through bgfx read/update calls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb943245e083318f92e5029c07d0b8