### PR TITLE
Introduce bgfx shader program registry scaffolding

### DIFF
--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DShaderManager.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DShaderManager.h
@@ -137,6 +137,7 @@ public:
 	static void startRenderToTexture(void); ///< Sets render target to texture.
 	static IDirect3DTexture8 * endRenderToTexture(void); ///< Ends render to texture, & returns texture.
 	static IDirect3DTexture8 * getRenderTexture(void);	///< returns last used render target texture
+	static TextureClass * getRenderTextureClass(void);	///< returns wrapper for the render target texture
 	static void drawViewport(Int color);	///<draws 2 triangles covering the current tactical viewport
 
 
@@ -164,6 +165,8 @@ protected:
 	static IDirect3DTexture8 *m_renderTexture;		///<texture into which rendering will be redirected.
 	static IDirect3DSurface8 *m_newRenderSurface;	///<new render target inside m_renderTexture
 	static IDirect3DSurface8 *m_oldDepthSurface;	///<previous depth buffer surface
+	static TextureClass *m_renderTextureWrapper;	///<wrapper for render target texture
+	static WW3DFormat m_renderTextureFormat;	///<format of render target texture
 
 
 };

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DShaderManager.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DShaderManager.h
@@ -39,6 +39,14 @@
 #include "WW3D2/Texture.h"
 #include <map>
 #include <string>
+
+#ifndef WW3D_BGFX_AVAILABLE
+#define WW3D_BGFX_AVAILABLE 0
+#endif
+
+#if WW3D_BGFX_AVAILABLE
+#include <bgfx/bgfx.h>
+#endif
 enum FilterTypes;
 enum CustomScenePassModes;
 enum StaticGameLODLevel;
@@ -62,9 +70,21 @@ public:
 
                 std::string m_vertexShaderPath;
                 std::string m_fragmentShaderPath;
+                std::string m_vertexShaderSourcePath;
+                std::string m_fragmentShaderSourcePath;
+                std::string m_varyingDefPath;
+                std::string m_vertexShaderProfile;
+                std::string m_fragmentShaderProfile;
                 Bool m_preload;
 
+#if WW3D_BGFX_AVAILABLE
+                bgfx::ProgramHandle m_programHandle;
+#endif
+
                 Bool isValid(void) const;
+                void setSourcePaths(const std::string &vertexSourcePath, const std::string &fragmentSourcePath);
+                void setVaryingPath(const std::string &varyingPath);
+                void setShaderProfiles(const std::string &vertexProfile, const std::string &fragmentProfile);
         };
 
         //put any custom shaders (not going through W3D) in here.
@@ -126,8 +146,16 @@ protected:
 	static ShaderTypes m_currentShader;	///<last shader that was set.
 	static Int m_currentShaderPass;		///<pass of last shader that was set.
 
-	static void initializeDefaultBgfxPrograms(void);
-	static std::map<ShaderTypes, BgfxProgramDefinition> m_bgfxPrograms;
+        static void initializeDefaultBgfxPrograms(void);
+        static void preloadBgfxPrograms(void);
+        static void unloadBgfxPrograms(void);
+#if WW3D_BGFX_AVAILABLE
+        static Bool ensureBgfxProgramLoaded(ShaderTypes shader);
+        static Bool ensureBgfxShaderBinary(const std::string &binaryPath, const std::string &sourcePath, const std::string &profile, const std::string &varyingPath, const char *stageLabel);
+        static void destroyBgfxProgram(BgfxProgramDefinition &definition);
+        static bgfx::ProgramHandle loadBgfxProgram(BgfxProgramDefinition &definition);
+#endif
+        static std::map<ShaderTypes, BgfxProgramDefinition> m_bgfxPrograms;
 
 	static FilterTypes m_currentFilter; ///< Last filter that was set.
 	// Info for a render to texture surface for special effects.

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DShaderManager.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DShaderManager.h
@@ -37,6 +37,8 @@
 #define __W3DSHADERMANAGER_H_
 
 #include "WW3D2/Texture.h"
+#include <map>
+#include <string>
 enum FilterTypes;
 enum CustomScenePassModes;
 enum StaticGameLODLevel;
@@ -53,8 +55,20 @@ class W3DShaderManager
 {
 public:
 
-	//put any custom shaders (not going through W3D) in here.
-	enum ShaderTypes
+        struct BgfxProgramDefinition
+        {
+                BgfxProgramDefinition();
+                BgfxProgramDefinition(const std::string &vertexPath, const std::string &fragmentPath, Bool preload = true);
+
+                std::string m_vertexShaderPath;
+                std::string m_fragmentShaderPath;
+                Bool m_preload;
+
+                Bool isValid(void) const;
+        };
+
+        //put any custom shaders (not going through W3D) in here.
+        enum ShaderTypes
 	{	ST_INVALID,			//invalid shader type.
 		ST_TERRAIN_BASE,	//shader to apply base terrain texture only
 		ST_TERRAIN_BASE_NOISE1,	//shader to apply base texture and cloud/noise 1.
@@ -83,9 +97,11 @@ public:
 	///Return current texture available to shaders.
 	static inline TextureClass *getShaderTexture(Int stage) { return m_Textures[stage];}	///<returns currently selected texture for given stage
 	///Return last activated shader.
-	static inline ShaderTypes getCurrentShader(void) {return m_currentShader;}
-	/// Loads a .vso file and creates a vertex shader for it
-	static HRESULT LoadAndCreateD3DShader(char* strFilePath, const DWORD* pDeclaration, DWORD Usage, Bool ShaderType, DWORD* pHandle);
+        static inline ShaderTypes getCurrentShader(void) {return m_currentShader;}
+        static void registerBgfxProgram(ShaderTypes shader, const BgfxProgramDefinition &definition);
+        static const BgfxProgramDefinition *getBgfxProgram(ShaderTypes shader);
+        /// Loads a .vso file and creates a vertex shader for it
+        static HRESULT LoadAndCreateD3DShader(char* strFilePath, const DWORD* pDeclaration, DWORD Usage, Bool ShaderType, DWORD* pHandle);
 
 	static Bool testMinimumRequirements(ChipsetType *videoChipType, CpuType *cpuType, Int *cpuFreq, Int *numRAM, Real *intBenchIndex, Real *floatBenchIndex, Real *memBenchIndex);
 	static StaticGameLODLevel getGPUPerformanceIndex(void);
@@ -109,6 +125,9 @@ protected:
 	static ChipsetType m_currentChipset;	///<last video card chipset that was detected.
 	static ShaderTypes m_currentShader;	///<last shader that was set.
 	static Int m_currentShaderPass;		///<pass of last shader that was set.
+
+	static void initializeDefaultBgfxPrograms(void);
+	static std::map<ShaderTypes, BgfxProgramDefinition> m_bgfxPrograms;
 
 	static FilterTypes m_currentFilter; ///< Last filter that was set.
 	// Info for a render to texture surface for special effects.

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -505,6 +505,55 @@ inline DWORD F2DW(float f) { return *((unsigned*)&f); }
 
 static void Set_Default_Global_Render_States_Bgfx()
 {
+#if WW3D_BGFX_AVAILABLE
+        DX8Wrapper::FogEnable = false;
+        DX8Wrapper::FogColor = 0;
+
+        DX8Wrapper::RenderStates[D3DRS_RANGEFOGENABLE] = FALSE;
+        DX8Wrapper::RenderStates[D3DRS_FOGTABLEMODE] = D3DFOG_NONE;
+        DX8Wrapper::RenderStates[D3DRS_FOGVERTEXMODE] = D3DFOG_LINEAR;
+        DX8Wrapper::RenderStates[D3DRS_SPECULARMATERIALSOURCE] = D3DMCS_MATERIAL;
+        DX8Wrapper::RenderStates[D3DRS_COLORVERTEX] = TRUE;
+        DX8Wrapper::RenderStates[D3DRS_ZBIAS] = 0;
+
+        DX8Wrapper::TextureStageStates[1][D3DTSS_BUMPENVLSCALE] = F2DW(1.0f);
+        DX8Wrapper::TextureStageStates[1][D3DTSS_BUMPENVLOFFSET] = F2DW(0.0f);
+        DX8Wrapper::TextureStageStates[0][D3DTSS_BUMPENVMAT00] = F2DW(1.0f);
+        DX8Wrapper::TextureStageStates[0][D3DTSS_BUMPENVMAT01] = F2DW(0.0f);
+        DX8Wrapper::TextureStageStates[0][D3DTSS_BUMPENVMAT10] = F2DW(0.0f);
+        DX8Wrapper::TextureStageStates[0][D3DTSS_BUMPENVMAT11] = F2DW(1.0f);
+
+        BgfxStateData &bgfx_state = DX8Wrapper::render_state.bgfx;
+        bgfx_state = BgfxStateData();
+
+        bgfx_state.stateFlags = BGFX_STATE_WRITE_RGB | BGFX_STATE_WRITE_A |
+                BGFX_STATE_WRITE_Z | BGFX_STATE_DEPTH_TEST_LEQUAL;
+        bgfx_state.alphaTestEnabled = false;
+        bgfx_state.alphaFunc = D3DCMP_ALWAYS;
+        bgfx_state.alphaReference = 0.0f;
+        bgfx_state.materialLightingEnabled = false;
+        bgfx_state.ambientSource = D3DMCS_MATERIAL;
+        bgfx_state.diffuseSource = D3DMCS_MATERIAL;
+        bgfx_state.emissiveSource = D3DMCS_MATERIAL;
+
+        for (unsigned stage = 0; stage < MAX_TEXTURE_STAGES; ++stage)
+        {
+                bgfx_state.textureBindings[stage] = NULL;
+                bgfx_state.textureEnabled[stage] = false;
+                bgfx_state.uvSource[stage] = static_cast<uint8_t>(stage);
+                bgfx_state.textureAddressU[stage] = D3DTADDRESS_WRAP;
+                bgfx_state.textureAddressV[stage] = D3DTADDRESS_WRAP;
+                bgfx_state.textureTransformFlags[stage] = D3DTTFF_DISABLE;
+                bgfx_state.textureTransforms[stage].Make_Identity();
+                bgfx_state.textureTransformUsed[stage] = false;
+                bgfx_state.minFilter[stage] = D3DTEXF_LINEAR;
+                bgfx_state.magFilter[stage] = D3DTEXF_LINEAR;
+                bgfx_state.mipFilter[stage] = D3DTEXF_LINEAR;
+                bgfx_state.samplerFlags[stage] = BGFX_SAMPLER_NONE;
+        }
+
+        bgfx_state.program.idx = bgfx::kInvalidHandle;
+#else
         DX8Wrapper::Set_DX8_Render_State(D3DRS_RANGEFOGENABLE, FALSE);
         DX8Wrapper::Set_DX8_Render_State(D3DRS_FOGTABLEMODE, D3DFOG_NONE);
         DX8Wrapper::Set_DX8_Render_State(D3DRS_FOGVERTEXMODE, D3DFOG_LINEAR);
@@ -517,6 +566,7 @@ static void Set_Default_Global_Render_States_Bgfx()
         DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_BUMPENVMAT01,F2DW(0.0f));
         DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_BUMPENVMAT10,F2DW(0.0f));
         DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_BUMPENVMAT11,F2DW(1.0f));
+#endif
 }
 
 #if WW3D_BGFX_AVAILABLE

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -561,6 +561,55 @@ inline DWORD F2DW(float f) { return *((unsigned*)&f); }
 
 static void Set_Default_Global_Render_States_Bgfx()
 {
+#if WW3D_BGFX_AVAILABLE
+        DX8Wrapper::FogEnable = false;
+        DX8Wrapper::FogColor = 0;
+
+        DX8Wrapper::RenderStates[D3DRS_RANGEFOGENABLE] = FALSE;
+        DX8Wrapper::RenderStates[D3DRS_FOGTABLEMODE] = D3DFOG_NONE;
+        DX8Wrapper::RenderStates[D3DRS_FOGVERTEXMODE] = D3DFOG_LINEAR;
+        DX8Wrapper::RenderStates[D3DRS_SPECULARMATERIALSOURCE] = D3DMCS_MATERIAL;
+        DX8Wrapper::RenderStates[D3DRS_COLORVERTEX] = TRUE;
+        DX8Wrapper::RenderStates[D3DRS_ZBIAS] = 0;
+
+        DX8Wrapper::TextureStageStates[1][D3DTSS_BUMPENVLSCALE] = F2DW(1.0f);
+        DX8Wrapper::TextureStageStates[1][D3DTSS_BUMPENVLOFFSET] = F2DW(0.0f);
+        DX8Wrapper::TextureStageStates[0][D3DTSS_BUMPENVMAT00] = F2DW(1.0f);
+        DX8Wrapper::TextureStageStates[0][D3DTSS_BUMPENVMAT01] = F2DW(0.0f);
+        DX8Wrapper::TextureStageStates[0][D3DTSS_BUMPENVMAT10] = F2DW(0.0f);
+        DX8Wrapper::TextureStageStates[0][D3DTSS_BUMPENVMAT11] = F2DW(1.0f);
+
+        BgfxStateData &bgfx_state = DX8Wrapper::render_state.bgfx;
+        bgfx_state = BgfxStateData();
+
+        bgfx_state.stateFlags = BGFX_STATE_WRITE_RGB | BGFX_STATE_WRITE_A |
+                BGFX_STATE_WRITE_Z | BGFX_STATE_DEPTH_TEST_LEQUAL;
+        bgfx_state.alphaTestEnabled = false;
+        bgfx_state.alphaFunc = D3DCMP_ALWAYS;
+        bgfx_state.alphaReference = 0.0f;
+        bgfx_state.materialLightingEnabled = false;
+        bgfx_state.ambientSource = D3DMCS_MATERIAL;
+        bgfx_state.diffuseSource = D3DMCS_MATERIAL;
+        bgfx_state.emissiveSource = D3DMCS_MATERIAL;
+
+        for (unsigned stage = 0; stage < MAX_TEXTURE_STAGES; ++stage)
+        {
+                bgfx_state.textureBindings[stage] = NULL;
+                bgfx_state.textureEnabled[stage] = false;
+                bgfx_state.uvSource[stage] = static_cast<uint8_t>(stage);
+                bgfx_state.textureAddressU[stage] = D3DTADDRESS_WRAP;
+                bgfx_state.textureAddressV[stage] = D3DTADDRESS_WRAP;
+                bgfx_state.textureTransformFlags[stage] = D3DTTFF_DISABLE;
+                bgfx_state.textureTransforms[stage].Make_Identity();
+                bgfx_state.textureTransformUsed[stage] = false;
+                bgfx_state.minFilter[stage] = D3DTEXF_LINEAR;
+                bgfx_state.magFilter[stage] = D3DTEXF_LINEAR;
+                bgfx_state.mipFilter[stage] = D3DTEXF_LINEAR;
+                bgfx_state.samplerFlags[stage] = BGFX_SAMPLER_NONE;
+        }
+
+        bgfx_state.program.idx = bgfx::kInvalidHandle;
+#else
         DX8Wrapper::Set_DX8_Render_State(D3DRS_RANGEFOGENABLE, FALSE);
         DX8Wrapper::Set_DX8_Render_State(D3DRS_FOGTABLEMODE, D3DFOG_NONE);
         DX8Wrapper::Set_DX8_Render_State(D3DRS_FOGVERTEXMODE, D3DFOG_LINEAR);
@@ -573,6 +622,7 @@ static void Set_Default_Global_Render_States_Bgfx()
         DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_BUMPENVMAT01,F2DW(0.0f));
         DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_BUMPENVMAT10,F2DW(0.0f));
         DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_BUMPENVMAT11,F2DW(1.0f));
+#endif
 }
 void DX8Wrapper::Set_Default_Global_Render_States(void)
 {


### PR DESCRIPTION
## Summary
- add a `BgfxProgramDefinition` helper to W3DShaderManager for tracking bgfx shader binaries
- expose registration/query helpers and seed default program descriptors during init
- clear the new registry on shutdown so shader selections can be rebuilt

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb9fe302dc833191bbee5fd68717cf