### PR TITLE
Add bgfx texture fallback and integration

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.h
@@ -479,6 +479,17 @@ public:
 
 protected:
 
+
+#if WW3D_BGFX_AVAILABLE
+	static void Create_Bgfx_Texture_For_Owner(TextureClass* texture_owner,
+		IDirect3DTexture8* texture,
+		WW3DFormat requested_format,
+		unsigned int width,
+		unsigned int height,
+		TextureClass::MipCountType mip_level_count,
+		bool render_target);
+#endif
+
 	static bool	Create_Device(void);
 	static void Release_Device(void);
 

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/texture.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/texture.h
@@ -248,11 +248,13 @@ class TextureClass : public W3DMPO, public RefCountClass
                         uint64_t                                                flags;
                 };
 
-		void Destroy_Bgfx_Resources();
-		void Upload_Bgfx_Texture(uint16_t width, uint16_t height, WW3DFormat format, uint8_t mip_count, bool render_target, const uint8_t* const* data, const uint32_t* pitches);
-		void Create_Bgfx_Texture_From_D3D(IDirect3DTexture8* texture, WW3DFormat format, bool render_target);
-		void Create_Bgfx_Texture_From_Locked_Task(TextureLoadTaskClass* task);
-		BgfxTextureInfo m_bgfxData;
+                void Destroy_Bgfx_Resources();
+                void Upload_Bgfx_Texture(uint16_t width, uint16_t height, WW3DFormat format, uint8_t mip_count, bool render_target, const uint8_t* const* data, const uint32_t* pitches);
+                void Create_Bgfx_Texture_From_D3D(IDirect3DTexture8* texture, WW3DFormat format, bool render_target);
+                void Create_Bgfx_Texture_From_Locked_Task(TextureLoadTaskClass* task);
+                static uint8_t Calculate_Max_Bgfx_Mip_Count(uint16_t width, uint16_t height);
+                static uint8_t Calculate_Bgfx_Mip_Count(uint16_t width, uint16_t height, MipCountType mip_level_count);
+                BgfxTextureInfo m_bgfxData;
 #endif
 
 		// State not contained in the Direct3D texture object:

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/textureloader.cpp
@@ -1297,16 +1297,25 @@ void TextureLoadTaskClass::Set_D3D_Texture(IDirect3DTexture8* texture)
 
 void TextureLoadTaskClass::Apply(bool initialize)
 {
-	WWASSERT(D3DTexture);
-	// Verify that none of the mip levels are locked
-	for (unsigned i=0;i<MipLevelCount;++i) {
-		WWASSERT(LockedSurfacePtr[i]==NULL);
-	}
+        // Verify that none of the mip levels are locked
+        for (unsigned i=0;i<MipLevelCount;++i) {
+                WWASSERT(LockedSurfacePtr[i]==NULL);
+        }
 
-	Texture->Apply_New_Surface(initialize);
+#if WW3D_BGFX_AVAILABLE
+        if (!D3DTexture && DX8Wrapper::Is_Bgfx_Active() && Texture && Texture->Has_Bgfx_Texture())
+        {
+                Texture->Apply_New_Surface(initialize);
+                return;
+        }
+#endif
 
-	D3DTexture->Release();
-	D3DTexture=NULL;
+        WWASSERT(D3DTexture);
+
+        Texture->Apply_New_Surface(initialize);
+
+        D3DTexture->Release();
+        D3DTexture=NULL;
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a DX8Wrapper helper that mirrors Direct3D texture creation into bgfx, including graceful fallback when the Direct3D allocation fails
- extend TextureClass with mip count helpers, upload paths, and Apply_New_Surface tweaks so bgfx-only textures remain initialized
- update texture/surface loaders to recognize bgfx-backed resources and avoid assuming a Direct3D texture always exists

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc054e774c8331883afbb5ac31ce4e