### PR TITLE
Add bgfx shader metadata and source placeholders

### DIFF
--- a/Generals/.gitignore
+++ b/Generals/.gitignore
@@ -1,6 +1,10 @@
 
 # Ignore RUNable folder
-[Rr]un
+[Rr]un/*
+![Rr]un/BrowserEngine.dll
+![Rr]un/place_steam_build_here.txt
+![Rr]un/shaders/
+![Rr]un/shaders/**
 
 # Build output folders
 [Rr]elease*

--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DShaderManager.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DShaderManager.h
@@ -37,8 +37,10 @@
 #define __W3DSHADERMANAGER_H_
 
 #include "WW3D2/Texture.h"
+#include <cstdint>
 #include <map>
 #include <string>
+#include <vector>
 
 #ifndef WW3D_BGFX_AVAILABLE
 #define WW3D_BGFX_AVAILABLE 0
@@ -68,6 +70,19 @@ public:
                 BgfxProgramDefinition();
                 BgfxProgramDefinition(const std::string &vertexPath, const std::string &fragmentPath, Bool preload = true);
 
+                struct BgfxSamplerBinding
+                {
+                        std::string m_name;
+                        std::uint8_t m_stage;
+                };
+
+                struct BgfxUniformBinding
+                {
+                        std::string m_name;
+                        std::string m_type;
+                        std::uint16_t m_arraySize;
+                };
+
                 std::string m_vertexShaderPath;
                 std::string m_fragmentShaderPath;
                 std::string m_vertexShaderSourcePath;
@@ -76,6 +91,8 @@ public:
                 std::string m_vertexShaderProfile;
                 std::string m_fragmentShaderProfile;
                 Bool m_preload;
+                std::vector<BgfxSamplerBinding> m_samplerBindings;
+                std::vector<BgfxUniformBinding> m_uniformBindings;
 
 #if WW3D_BGFX_AVAILABLE
                 bgfx::ProgramHandle m_programHandle;
@@ -85,6 +102,8 @@ public:
                 void setSourcePaths(const std::string &vertexSourcePath, const std::string &fragmentSourcePath);
                 void setVaryingPath(const std::string &varyingPath);
                 void setShaderProfiles(const std::string &vertexProfile, const std::string &fragmentProfile);
+                void addSampler(const std::string &name, std::uint8_t stage);
+                void addUniform(const std::string &name, const std::string &type, std::uint16_t arraySize = 1);
         };
 
         //put any custom shaders (not going through W3D) in here.

--- a/Generals/Run/shaders/bgfx/README.md
+++ b/Generals/Run/shaders/bgfx/README.md
@@ -1,0 +1,27 @@
+# BGFX shader sources
+
+This directory contains the reference sources used by the runtime shader compilation
+path inside `W3DShaderManager`. Each shader has an associated `.sc` file for the vertex
+and fragment stages as well as a shared `varying.def.sc` declaration. The shader manager
+looks for compiled binaries in `shaders/bgfx/*.bin` at runtime and will invoke
+`shaderc` to rebuild them when the source timestamp is newer than the binary.
+
+The `BgfxProgramDefinition` metadata registered from C++ describes the uniform and
+sampler layout exposed by each shader program. These definitions act as the contract for
+future work that will bind BGFX uniforms instead of legacy Direct3D texture stage state.
+
+## Uniform conventions
+
+* `u_modelViewProj` – world/view/projection transform for the current draw.
+* `u_texTransform` – array of up to four texture projection matrices used to replicate
+  the legacy camera-space projections for cloud/noise passes.
+* `u_layerConfig` – general purpose parameters for terrain/road layering. Components
+  map to detail and noise blend factors.
+* `u_fadeConfig`, `u_shroudParams`, `u_maskParams`, `u_cloudParams` – shader specific
+  parameters that will be populated by the shader manager when the bgfx path is wired
+  up to the game logic.
+
+All shader sources rely on standard BGFX includes and assume the vertex format exposes
+`a_position`, `a_color0`, and at least two sets of texture coordinates. The extra
+varyings are written even when unused so the compiled programs have a uniform interface
+across the different terrain permutations.

--- a/Generals/Run/shaders/bgfx/src/cloud.fs.sc
+++ b/Generals/Run/shaders/bgfx/src/cloud.fs.sc
@@ -1,0 +1,16 @@
+$input v_color0, v_texcoord0, v_texcoord1, v_texcoord2, v_texcoord3
+
+#include <bgfx_shader.sh>
+
+uniform vec4 u_cloudParams;
+
+SAMPLER2D(s_cloudTexture, 0);
+
+void main()
+{
+    vec4 cloudSample = texture2D(s_cloudTexture, v_texcoord0);
+    float intensity = clamp(u_cloudParams.x, 0.0, 1.0);
+    vec4 color = vec4(cloudSample.rgb * v_color0.rgb, cloudSample.a * v_color0.a);
+    color *= intensity;
+    gl_FragColor = color;
+}

--- a/Generals/Run/shaders/bgfx/src/cloud.vs.sc
+++ b/Generals/Run/shaders/bgfx/src/cloud.vs.sc
@@ -1,0 +1,19 @@
+$input a_position, a_color0, a_texcoord0
+$output v_color0, v_texcoord0, v_texcoord1, v_texcoord2, v_texcoord3
+
+#include <bgfx_shader.sh>
+
+uniform mat4 u_modelViewProj;
+uniform mat4 u_texTransform[4];
+
+void main()
+{
+    vec4 position = vec4(a_position, 1.0);
+    gl_Position = mul(u_modelViewProj, position);
+
+    v_color0 = a_color0;
+    v_texcoord0 = a_texcoord0;
+    v_texcoord1 = (mul(u_texTransform[1], position)).xy;
+    v_texcoord2 = (mul(u_texTransform[2], position)).xy;
+    v_texcoord3 = (mul(u_texTransform[3], position)).xy;
+}

--- a/Generals/Run/shaders/bgfx/src/mask.fs.sc
+++ b/Generals/Run/shaders/bgfx/src/mask.fs.sc
@@ -1,0 +1,16 @@
+$input v_color0, v_texcoord0, v_texcoord1, v_texcoord2, v_texcoord3
+
+#include <bgfx_shader.sh>
+
+uniform vec4 u_maskParams;
+
+SAMPLER2D(s_maskTexture, 0);
+
+void main()
+{
+    vec4 maskSample = texture2D(s_maskTexture, v_texcoord0);
+    float intensity = clamp(u_maskParams.x, 0.0, 1.0);
+    vec4 color = vec4(maskSample.rgb * v_color0.rgb, maskSample.a * v_color0.a);
+    color *= intensity;
+    gl_FragColor = color;
+}

--- a/Generals/Run/shaders/bgfx/src/mask.vs.sc
+++ b/Generals/Run/shaders/bgfx/src/mask.vs.sc
@@ -1,0 +1,19 @@
+$input a_position, a_color0, a_texcoord0
+$output v_color0, v_texcoord0, v_texcoord1, v_texcoord2, v_texcoord3
+
+#include <bgfx_shader.sh>
+
+uniform mat4 u_modelViewProj;
+uniform mat4 u_texTransform[4];
+
+void main()
+{
+    vec4 position = vec4(a_position, 1.0);
+    gl_Position = mul(u_modelViewProj, position);
+
+    v_color0 = a_color0;
+    v_texcoord0 = a_texcoord0;
+    v_texcoord1 = (mul(u_texTransform[1], position)).xy;
+    v_texcoord2 = (mul(u_texTransform[2], position)).xy;
+    v_texcoord3 = (mul(u_texTransform[3], position)).xy;
+}

--- a/Generals/Run/shaders/bgfx/src/road_base.fs.sc
+++ b/Generals/Run/shaders/bgfx/src/road_base.fs.sc
@@ -1,0 +1,27 @@
+$input v_color0, v_texcoord0, v_texcoord1, v_texcoord2, v_texcoord3
+
+#include <bgfx_shader.sh>
+
+uniform vec4 u_layerConfig;
+uniform vec4 u_fadeConfig;
+
+SAMPLER2D(s_roadTexture, 0);
+SAMPLER2D(s_detailTexture, 1);
+
+vec4 applyDetailLayer(vec4 baseColor, vec4 detailColor, float blendWeight)
+{
+    float weight = clamp(blendWeight, 0.0, 1.0);
+    return mix(baseColor, baseColor * detailColor, weight);
+}
+
+void main()
+{
+    vec4 roadSample = texture2D(s_roadTexture, v_texcoord0);
+    vec4 detailSample = texture2D(s_detailTexture, v_texcoord1);
+
+    vec4 color = roadSample * v_color0;
+    color = applyDetailLayer(color, detailSample, u_layerConfig.x);
+    color.a *= clamp(u_fadeConfig.x, 0.0, 1.0);
+
+    gl_FragColor = color;
+}

--- a/Generals/Run/shaders/bgfx/src/road_base.vs.sc
+++ b/Generals/Run/shaders/bgfx/src/road_base.vs.sc
@@ -1,0 +1,19 @@
+$input a_position, a_color0, a_texcoord0, a_texcoord1
+$output v_color0, v_texcoord0, v_texcoord1, v_texcoord2, v_texcoord3
+
+#include <bgfx_shader.sh>
+
+uniform mat4 u_modelViewProj;
+uniform mat4 u_texTransform[4];
+
+void main()
+{
+    vec4 position = vec4(a_position, 1.0);
+    gl_Position = mul(u_modelViewProj, position);
+
+    v_color0 = a_color0;
+    v_texcoord0 = a_texcoord0;
+    v_texcoord1 = a_texcoord1;
+    v_texcoord2 = (mul(u_texTransform[2], position)).xy;
+    v_texcoord3 = (mul(u_texTransform[3], position)).xy;
+}

--- a/Generals/Run/shaders/bgfx/src/road_noise.fs.sc
+++ b/Generals/Run/shaders/bgfx/src/road_noise.fs.sc
@@ -1,0 +1,39 @@
+$input v_color0, v_texcoord0, v_texcoord1, v_texcoord2, v_texcoord3
+
+#include <bgfx_shader.sh>
+
+uniform vec4 u_layerConfig;
+uniform vec4 u_fadeConfig;
+
+SAMPLER2D(s_roadTexture, 0);
+SAMPLER2D(s_detailTexture, 1);
+SAMPLER2D(s_noiseTexture0, 2);
+SAMPLER2D(s_noiseTexture1, 3);
+
+vec4 applyDetailLayer(vec4 baseColor, vec4 detailColor, float blendWeight)
+{
+    float weight = clamp(blendWeight, 0.0, 1.0);
+    return mix(baseColor, baseColor * detailColor, weight);
+}
+
+vec3 applyNoiseLayer(vec3 baseColor, vec4 noiseColor, float weight)
+{
+    float noiseWeight = clamp(weight, 0.0, 1.0);
+    return mix(baseColor, baseColor * noiseColor.rgb, noiseWeight);
+}
+
+void main()
+{
+    vec4 roadSample = texture2D(s_roadTexture, v_texcoord0);
+    vec4 detailSample = texture2D(s_detailTexture, v_texcoord1);
+    vec4 noiseSample0 = texture2D(s_noiseTexture0, v_texcoord2);
+    vec4 noiseSample1 = texture2D(s_noiseTexture1, v_texcoord3);
+
+    vec4 color = roadSample * v_color0;
+    color = applyDetailLayer(color, detailSample, u_layerConfig.x);
+    color.rgb = applyNoiseLayer(color.rgb, noiseSample0, u_layerConfig.y);
+    color.rgb = applyNoiseLayer(color.rgb, noiseSample1, u_layerConfig.z);
+    color.a *= clamp(u_fadeConfig.x, 0.0, 1.0);
+
+    gl_FragColor = color;
+}

--- a/Generals/Run/shaders/bgfx/src/road_noise.vs.sc
+++ b/Generals/Run/shaders/bgfx/src/road_noise.vs.sc
@@ -1,0 +1,19 @@
+$input a_position, a_color0, a_texcoord0, a_texcoord1
+$output v_color0, v_texcoord0, v_texcoord1, v_texcoord2, v_texcoord3
+
+#include <bgfx_shader.sh>
+
+uniform mat4 u_modelViewProj;
+uniform mat4 u_texTransform[4];
+
+void main()
+{
+    vec4 position = vec4(a_position, 1.0);
+    gl_Position = mul(u_modelViewProj, position);
+
+    v_color0 = a_color0;
+    v_texcoord0 = a_texcoord0;
+    v_texcoord1 = a_texcoord1;
+    v_texcoord2 = (mul(u_texTransform[2], position)).xy;
+    v_texcoord3 = (mul(u_texTransform[3], position)).xy;
+}

--- a/Generals/Run/shaders/bgfx/src/shroud.fs.sc
+++ b/Generals/Run/shaders/bgfx/src/shroud.fs.sc
@@ -1,0 +1,16 @@
+$input v_color0, v_texcoord0, v_texcoord1, v_texcoord2, v_texcoord3
+
+#include <bgfx_shader.sh>
+
+uniform vec4 u_shroudParams;
+
+SAMPLER2D(s_shroudTexture, 0);
+
+void main()
+{
+    vec4 shroud = texture2D(s_shroudTexture, v_texcoord0);
+    float opacity = clamp(u_shroudParams.x, 0.0, 1.0);
+    vec4 color = vec4(shroud.rgb * v_color0.rgb, shroud.a * v_color0.a);
+    color.a *= opacity;
+    gl_FragColor = color;
+}

--- a/Generals/Run/shaders/bgfx/src/shroud.vs.sc
+++ b/Generals/Run/shaders/bgfx/src/shroud.vs.sc
@@ -1,0 +1,19 @@
+$input a_position, a_color0
+$output v_color0, v_texcoord0, v_texcoord1, v_texcoord2, v_texcoord3
+
+#include <bgfx_shader.sh>
+
+uniform mat4 u_modelViewProj;
+uniform mat4 u_texTransform[4];
+
+void main()
+{
+    vec4 position = vec4(a_position, 1.0);
+    gl_Position = mul(u_modelViewProj, position);
+
+    v_color0 = a_color0;
+    v_texcoord0 = (mul(u_texTransform[0], position)).xy;
+    v_texcoord1 = (mul(u_texTransform[1], position)).xy;
+    v_texcoord2 = (mul(u_texTransform[2], position)).xy;
+    v_texcoord3 = (mul(u_texTransform[3], position)).xy;
+}

--- a/Generals/Run/shaders/bgfx/src/terrain_base.fs.sc
+++ b/Generals/Run/shaders/bgfx/src/terrain_base.fs.sc
@@ -1,0 +1,25 @@
+$input v_color0, v_texcoord0, v_texcoord1, v_texcoord2, v_texcoord3
+
+#include <bgfx_shader.sh>
+
+uniform vec4 u_layerConfig;
+
+SAMPLER2D(s_baseTexture, 0);
+SAMPLER2D(s_detailTexture, 1);
+
+vec4 applyDetailLayer(vec4 baseColor, vec4 detailColor, float blendWeight)
+{
+    float weight = clamp(blendWeight, 0.0, 1.0);
+    return mix(baseColor, baseColor * detailColor, weight);
+}
+
+void main()
+{
+    vec4 baseSample = texture2D(s_baseTexture, v_texcoord0);
+    vec4 detailSample = texture2D(s_detailTexture, v_texcoord1);
+
+    vec4 color = baseSample * v_color0;
+    color = applyDetailLayer(color, detailSample, u_layerConfig.x);
+
+    gl_FragColor = color;
+}

--- a/Generals/Run/shaders/bgfx/src/terrain_base.vs.sc
+++ b/Generals/Run/shaders/bgfx/src/terrain_base.vs.sc
@@ -1,0 +1,19 @@
+$input a_position, a_color0, a_texcoord0, a_texcoord1
+$output v_color0, v_texcoord0, v_texcoord1, v_texcoord2, v_texcoord3
+
+#include <bgfx_shader.sh>
+
+uniform mat4 u_modelViewProj;
+uniform mat4 u_texTransform[4];
+
+void main()
+{
+    vec4 position = vec4(a_position, 1.0);
+    gl_Position = mul(u_modelViewProj, position);
+
+    v_color0 = a_color0;
+    v_texcoord0 = a_texcoord0;
+    v_texcoord1 = a_texcoord1;
+    v_texcoord2 = (mul(u_texTransform[2], position)).xy;
+    v_texcoord3 = (mul(u_texTransform[3], position)).xy;
+}

--- a/Generals/Run/shaders/bgfx/src/terrain_noise.fs.sc
+++ b/Generals/Run/shaders/bgfx/src/terrain_noise.fs.sc
@@ -1,0 +1,38 @@
+$input v_color0, v_texcoord0, v_texcoord1, v_texcoord2, v_texcoord3
+
+#include <bgfx_shader.sh>
+
+uniform vec4 u_layerConfig;
+
+SAMPLER2D(s_baseTexture, 0);
+SAMPLER2D(s_detailTexture, 1);
+SAMPLER2D(s_noiseTexture0, 2);
+SAMPLER2D(s_noiseTexture1, 3);
+
+vec4 applyDetailLayer(vec4 baseColor, vec4 detailColor, float blendWeight)
+{
+    float weight = clamp(blendWeight, 0.0, 1.0);
+    return mix(baseColor, baseColor * detailColor, weight);
+}
+
+vec3 applyNoiseLayer(vec3 baseColor, vec4 noiseColor, float weight)
+{
+    float noiseWeight = clamp(weight, 0.0, 1.0);
+    return mix(baseColor, baseColor * noiseColor.rgb, noiseWeight);
+}
+
+void main()
+{
+    vec4 baseSample = texture2D(s_baseTexture, v_texcoord0);
+    vec4 detailSample = texture2D(s_detailTexture, v_texcoord1);
+    vec4 noiseSample0 = texture2D(s_noiseTexture0, v_texcoord2);
+    vec4 noiseSample1 = texture2D(s_noiseTexture1, v_texcoord3);
+
+    vec4 color = baseSample * v_color0;
+    color = applyDetailLayer(color, detailSample, u_layerConfig.x);
+
+    color.rgb = applyNoiseLayer(color.rgb, noiseSample0, u_layerConfig.y);
+    color.rgb = applyNoiseLayer(color.rgb, noiseSample1, u_layerConfig.z);
+
+    gl_FragColor = color;
+}

--- a/Generals/Run/shaders/bgfx/src/terrain_noise.vs.sc
+++ b/Generals/Run/shaders/bgfx/src/terrain_noise.vs.sc
@@ -1,0 +1,19 @@
+$input a_position, a_color0, a_texcoord0, a_texcoord1
+$output v_color0, v_texcoord0, v_texcoord1, v_texcoord2, v_texcoord3
+
+#include <bgfx_shader.sh>
+
+uniform mat4 u_modelViewProj;
+uniform mat4 u_texTransform[4];
+
+void main()
+{
+    vec4 position = vec4(a_position, 1.0);
+    gl_Position = mul(u_modelViewProj, position);
+
+    v_color0 = a_color0;
+    v_texcoord0 = a_texcoord0;
+    v_texcoord1 = a_texcoord1;
+    v_texcoord2 = (mul(u_texTransform[2], position)).xy;
+    v_texcoord3 = (mul(u_texTransform[3], position)).xy;
+}

--- a/Generals/Run/shaders/bgfx/varying.def.sc
+++ b/Generals/Run/shaders/bgfx/varying.def.sc
@@ -1,0 +1,5 @@
+vec4 v_color0    : COLOR0;
+vec2 v_texcoord0 : TEXCOORD0;
+vec2 v_texcoord1 : TEXCOORD1;
+vec2 v_texcoord2 : TEXCOORD2;
+vec2 v_texcoord3 : TEXCOORD3;


### PR DESCRIPTION
## Summary
- allow tracking generated Run/shaders assets so BGFX sources can live beside the binaries
- extend BgfxProgramDefinition with sampler/uniform metadata and register shader sources, profiles, and varyings for default programs
- add BGFX shader source files and documentation describing the expected uniform layout for terrain, road, shroud, mask, and cloud programs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc17485654833195a87b34258e8487