### PR TITLE
Remove SafeDisk API references

### DIFF
--- a/Generals/Code/Main/WinMain.cpp
+++ b/Generals/Code/Main/WinMain.cpp
@@ -54,7 +54,6 @@
 #include "Common/GameSounds.h"
 #include "Common/Debug.h"
 #include "Common/GameMemory.h"
-#include "Common/SafeDisc/CdaPfn.h"
 #include "Common/StackDump.h"
 #include "Common/MessageStream.h"
 #include "Common/Team.h"
@@ -861,24 +860,10 @@ static Bool initializeAppWindows( HINSTANCE hInstance, Int nCmdShow, const Graph
 
 }  // end initializeAppWindows
 
-void munkeeFunc(void);
-CDAPFN_DECLARE_GLOBAL(munkeeFunc, CDAPFN_OVERHEAD_L5, CDAPFN_CONSTRAINT_NONE);
-void munkeeFunc(void)
-{
-	CDAPFN_ENDMARK(munkeeFunc);
-}
-
 void checkProtection(void)
 {
 #ifdef _INTERNAL
-	__try
-	{
-		munkeeFunc();
-	}
-	__except(EXCEPTION_EXECUTE_HANDLER)
-	{
-		exit(0); // someone is messing with us.
-	}
+        // Protection check removed.
 #endif
 }
 

--- a/Generals/Code/Tools/Launcher/DatGen/DatGen.cpp
+++ b/Generals/Code/Tools/Launcher/DatGen/DatGen.cpp
@@ -24,12 +24,10 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "bfish.h"
-#include "SafeDisk\CdaPfn.h"
 #include <Debug\DebugPrint.h>
 
 void __cdecl doIt(void);
 
-CDAPFN_DECLARE_GLOBAL(doIt, CDAPFN_OVERHEAD_L5, CDAPFN_CONSTRAINT_NONE);
 
 static void doIt(void)
 {
@@ -176,7 +174,7 @@ static void doIt(void)
 		fclose(fp);
 	}
 
-	CDAPFN_ENDMARK(doIt);
+
 }
 
 int APIENTRY WinMain(HINSTANCE hInstance,

--- a/Generals/Code/Tools/Launcher/DatGen/DatGen.dsp
+++ b/Generals/Code/Tools/Launcher/DatGen/DatGen.dsp
@@ -116,7 +116,6 @@ SOURCE=..\BFISH.H
 # End Source File
 # Begin Source File
 
-SOURCE=..\SafeDisk\CdaPfn.h
 # End Source File
 # Begin Source File
 

--- a/Generals/Code/Tools/Launcher/Protect.cpp
+++ b/Generals/Code/Tools/Launcher/Protect.cpp
@@ -47,7 +47,6 @@
 #include <stdio.h>
 #include <Debug\DebugPrint.h>
 
-#include "SafeDisk\CdaPfn.h"
 
 // This GUID should be unique for each product. (CHANGE IT WHEN DOING THE
 // NEXT PRODUCT) Note that the game will need to agree on this GUID also, so
@@ -112,7 +111,7 @@ void InitializeProtect(void)
 	}
 }
 
-CDAPFN_DECLARE_GLOBAL(SendProtectMessage, CDAPFN_OVERHEAD_L5, CDAPFN_CONSTRAINT_NONE);
+
 
 void SendProtectMessage(HANDLE process, DWORD threadID)
 {
@@ -314,7 +313,7 @@ void SendProtectMessage(HANDLE process, DWORD threadID)
 #endif
 
 	CloseHandle(event);
-	CDAPFN_ENDMARK(SendProtectMessage);
+	
 }
 
 

--- a/Generals/Code/Tools/Launcher/launcher.dsp
+++ b/Generals/Code/Tools/Launcher/launcher.dsp
@@ -218,14 +218,6 @@ SOURCE=.\Toolkit\Storage\Rights.h
 SOURCE=.\Toolkit\Storage\Stream.h
 # End Source File
 # End Group
-# Begin Group "SafeDisk"
-
-# PROP Default_Filter ""
-# Begin Source File
-
-SOURCE=.\SafeDisk\CdaPfn.h
-# End Source File
-# End Group
 # Begin Source File
 
 SOURCE=.\BFISH.CPP

--- a/Generals/Code/Tools/Launcher/main.cpp
+++ b/Generals/Code/Tools/Launcher/main.cpp
@@ -291,7 +291,7 @@ int main(int argc, char *argv[])
 		}
 		else
 		{
-			// Its still early in the product's lifetime, so run the 2nd (SafeDisk'd) launcher.
+			// Its still early in the product's lifetime, so run the second launcher.
 			// We don't have to wait around since it'll do the entire talk to game, look for patches,
 			// etc. deal.
 			RunLauncher(argv[0], proc2);

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -54,7 +54,6 @@
 #include "Common/GameSounds.h"
 #include "Common/Debug.h"
 #include "Common/GameMemory.h"
-#include "Common/SafeDisc/CdaPfn.h"
 #include "Common/StackDump.h"
 #include "Common/MessageStream.h"
 #include "Common/Registry.h"
@@ -897,24 +896,10 @@ static Bool initializeAppWindows( HINSTANCE hInstance, Int nCmdShow, const Graph
 
 }  // end initializeAppWindows
 
-void munkeeFunc(void);
-CDAPFN_DECLARE_GLOBAL(munkeeFunc, CDAPFN_OVERHEAD_L5, CDAPFN_CONSTRAINT_NONE);
-void munkeeFunc(void)
-{
-	CDAPFN_ENDMARK(munkeeFunc);
-}
-
 void checkProtection(void)
 {
 #ifdef _INTERNAL
-	__try
-	{
-		munkeeFunc();
-	}
-	__except(EXCEPTION_EXECUTE_HANDLER)
-	{
-		exit(0); // someone is messing with us.
-	}
+        // Protection check removed.
 #endif
 }
 

--- a/GeneralsMD/Code/Tools/Launcher/DatGen/DatGen.cpp
+++ b/GeneralsMD/Code/Tools/Launcher/DatGen/DatGen.cpp
@@ -24,12 +24,10 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "bfish.h"
-#include "SafeDisk\CdaPfn.h"
 #include <Debug\DebugPrint.h>
 
 void __cdecl doIt(void);
 
-CDAPFN_DECLARE_GLOBAL(doIt, CDAPFN_OVERHEAD_L5, CDAPFN_CONSTRAINT_NONE);
 
 static void doIt(void)
 {
@@ -176,7 +174,7 @@ static void doIt(void)
 		fclose(fp);
 	}
 
-	CDAPFN_ENDMARK(doIt);
+
 }
 
 int APIENTRY WinMain(HINSTANCE hInstance,

--- a/GeneralsMD/Code/Tools/Launcher/DatGen/DatGen.dsp
+++ b/GeneralsMD/Code/Tools/Launcher/DatGen/DatGen.dsp
@@ -115,7 +115,6 @@ SOURCE=..\BFISH.H
 # End Source File
 # Begin Source File
 
-SOURCE=..\SafeDisk\CdaPfn.h
 # End Source File
 # Begin Source File
 

--- a/GeneralsMD/Code/Tools/Launcher/Protect.cpp
+++ b/GeneralsMD/Code/Tools/Launcher/Protect.cpp
@@ -47,7 +47,6 @@
 #include <stdio.h>
 #include <Debug\DebugPrint.h>
 
-#include "SafeDisk\CdaPfn.h"
 
 // This GUID should be unique for each product. (CHANGE IT WHEN DOING THE
 // NEXT PRODUCT) Note that the game will need to agree on this GUID also, so
@@ -112,7 +111,7 @@ void InitializeProtect(void)
 	}
 }
 
-CDAPFN_DECLARE_GLOBAL(SendProtectMessage, CDAPFN_OVERHEAD_L5, CDAPFN_CONSTRAINT_NONE);
+
 
 void SendProtectMessage(HANDLE process, DWORD threadID)
 {
@@ -314,7 +313,7 @@ void SendProtectMessage(HANDLE process, DWORD threadID)
 #endif
 
 	CloseHandle(event);
-	CDAPFN_ENDMARK(SendProtectMessage);
+	
 }
 
 

--- a/GeneralsMD/Code/Tools/Launcher/launcher.dsp
+++ b/GeneralsMD/Code/Tools/Launcher/launcher.dsp
@@ -217,14 +217,6 @@ SOURCE=.\Toolkit\Storage\Rights.h
 SOURCE=.\Toolkit\Storage\Stream.h
 # End Source File
 # End Group
-# Begin Group "SafeDisk"
-
-# PROP Default_Filter ""
-# Begin Source File
-
-SOURCE=.\SafeDisk\CdaPfn.h
-# End Source File
-# End Group
 # Begin Source File
 
 SOURCE=.\BFISH.CPP

--- a/GeneralsMD/Code/Tools/Launcher/main.cpp
+++ b/GeneralsMD/Code/Tools/Launcher/main.cpp
@@ -291,7 +291,7 @@ int main(int argc, char *argv[])
 		}
 		else
 		{
-			// Its still early in the product's lifetime, so run the 2nd (SafeDisk'd) launcher.
+			// Its still early in the product's lifetime, so run the second launcher.
 			// We don't have to wait around since it'll do the entire talk to game, look for patches,
 			// etc. deal.
 			RunLauncher(argv[0], proc2);

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ If you wish to rebuild the source code and tools successfully you will need to f
 - BYTEmark - (expected path `\Code\Libraries\Source\Benchmark`)
 - RAD Miles Sound System SDK - (expected path `\Code\Libraries\Source\WWVegas\Miles6\`)
 - RAD Bink SDK - (expected path `\Code\GameEngineDevice\Include\VideoDevice\Bink`)
-- SafeDisk API - (expected path `\Code\GameEngine\Include\Common\SafeDisk` and `\Code\Tools\Launcher\SafeDisk\`)
 - Miles Sound System "Asimp3" - (expected path `\Code\Libraries\WPAudio\Asimp3`)
 - GameSpy SDK - (expected path `\Code\Libraries\Source\GameSpy\`)
 - ZLib (1.1.4) - (expected path `\Code\Libraries\Source\Compression\ZLib\`)


### PR DESCRIPTION
## Summary
- remove SafeDisk-specific includes and macros from launcher utilities and game entry points
- clean legacy project files and documentation to drop SafeDisk references
- update launcher comments to describe the remaining behavior without referencing SafeDisk

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc6c0066c08331aa6a80111a1e4b87