### PR TITLE
Refactor entry initialization and promote SFML entry point

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/GameEngine.h
+++ b/Generals/Code/GameEngine/Include/Common/GameEngine.h
@@ -114,6 +114,10 @@ extern GameEngine *TheGameEngine;
 /// This function creates a new game engine instance, and is device specific
 extern GameEngine *CreateGameEngine( void );
 
+typedef GameEngine *(*GameEngineFactoryFunction)();
+void SetGameEngineFactoryOverride(GameEngineFactoryFunction factory);
+GameEngineFactoryFunction GetGameEngineFactoryOverride();
+
 /// The entry point for the game system
 extern void GameMain( int argc, char *argv[] );
 

--- a/Generals/Code/Main/EntryPointLifecycle.cpp
+++ b/Generals/Code/Main/EntryPointLifecycle.cpp
@@ -1,0 +1,54 @@
+#include "EntryPointLifecycle.h"
+
+#include "WinMain.h"
+#include "Common/Debug.h"
+#include "Common/GameMemory.h"
+#include "Common/Version.h"
+#include "BuildVersion.h"
+#include "GeneratedVersion.h"
+
+void InitializeEntryPoint(const EntryPointConfig& config) {
+    ApplicationGraphicsBackend = config.graphicsBackend;
+
+    DEBUG_INIT(DEBUG_FLAGS_DEFAULT);
+    initMemoryManager();
+
+    if (TheVersion != NULL) {
+        delete TheVersion;
+        TheVersion = NULL;
+    }
+
+    TheVersion = NEW Version;
+    TheVersion->setVersion(VERSION_MAJOR, VERSION_MINOR, VERSION_BUILDNUM, VERSION_LOCALBUILDNUM,
+                           AsciiString(VERSION_BUILDUSER), AsciiString(VERSION_BUILDLOC),
+                           AsciiString(__TIME__), AsciiString(__DATE__));
+}
+
+void ShutdownEntryPoint() {
+    if (TheVersion != NULL) {
+        delete TheVersion;
+        TheVersion = NULL;
+    }
+
+    shutdownMemoryManager();
+    DEBUG_SHUTDOWN();
+}
+
+EntryPointScope::EntryPointScope(const EntryPointConfig& config)
+    : m_active(true) {
+    InitializeEntryPoint(config);
+}
+
+EntryPointScope::~EntryPointScope() {
+    if (m_active) {
+        ShutdownEntryPoint();
+    }
+}
+
+void EntryPointScope::dismiss() {
+    if (m_active) {
+        ShutdownEntryPoint();
+        m_active = false;
+    }
+}
+

--- a/Generals/Code/Main/EntryPointLifecycle.h
+++ b/Generals/Code/Main/EntryPointLifecycle.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "GraphicsBackend.h"
+
+struct EntryPointConfig {
+    GraphicsBackend graphicsBackend;
+};
+
+void InitializeEntryPoint(const EntryPointConfig& config);
+void ShutdownEntryPoint();
+
+class EntryPointScope {
+public:
+    explicit EntryPointScope(const EntryPointConfig& config);
+    ~EntryPointScope();
+
+    EntryPointScope(const EntryPointScope&) = delete;
+    EntryPointScope& operator=(const EntryPointScope&) = delete;
+
+    void dismiss();
+
+private:
+    bool m_active;
+};
+

--- a/Generals/Code/Main/GameEngineFactory.cpp
+++ b/Generals/Code/Main/GameEngineFactory.cpp
@@ -23,9 +23,37 @@
 
 Bool gInitialEngineActiveState = true;
 
+namespace {
+
+GameEngineFactoryFunction g_gameEngineFactoryOverride = NULL;
+
+}
+
+void SetGameEngineFactoryOverride(GameEngineFactoryFunction factory)
+{
+        g_gameEngineFactoryOverride = factory;
+}
+
+GameEngineFactoryFunction GetGameEngineFactoryOverride()
+{
+        return g_gameEngineFactoryOverride;
+}
+
 GameEngine* CreateGameEngine(void)
 {
-        Win32GameEngine* engine = NEW Win32GameEngine;
+        GameEngineFactoryFunction factory = GetGameEngineFactoryOverride();
+        GameEngine* engine = NULL;
+
+        if (factory != NULL)
+        {
+                engine = factory();
+        }
+
+        if (engine == NULL)
+        {
+                engine = NEW Win32GameEngine;
+        }
+
         engine->setIsActive(gInitialEngineActiveState);
         return engine;
 }

--- a/Generals/Code/RTS.dsp
+++ b/Generals/Code/RTS.dsp
@@ -131,7 +131,7 @@ SOURCE=.\Main\generatedVersion.h
 !IF  "$(CFG)" == "RTS - Win32 Release"
 
 # PROP Ignore_Default_Tool 1
-USERDEP__GENER="$(ProjDir)\main\winmain.cpp"	"$(ProjDir)\main\winmain.h"	"$(ProjDir)\Libraries\Lib\WW3D2.lib"	"$(ProjDir)\Libraries\Lib\WWDebug.lib"	"$(ProjDir)\Libraries\Lib\WWUtil.lib"	"$(ProjDir)\Libraries\Lib\WWLib.lib"	"$(ProjDir)\Libraries\Lib\WWMath.lib"	"$(ProjDir)\GameEngine\Lib\GameEngine.lib"	"$(ProjDir)\GameEngineDevice\Lib\GameEngineDevice.lib"	
+USERDEP__GENER="$(ProjDir)\SFMLPlatform\Main.cpp"	"$(ProjDir)\main\EntryPointLifecycle.cpp"	"$(ProjDir)\main\winmain.h"	"$(ProjDir)\Libraries\Lib\WW3D2.lib"	"$(ProjDir)\Libraries\Lib\WWDebug.lib"	"$(ProjDir)\Libraries\Lib\WWUtil.lib"	"$(ProjDir)\Libraries\Lib\WWLib.lib"	"$(ProjDir)\Libraries\Lib\WWMath.lib"	"$(ProjDir)\GameEngine\Lib\GameEngine.lib"	"$(ProjDir)\GameEngineDevice\Lib\GameEngineDevice.lib"	
 # Begin Custom Build - Incrementing version numbers held in $(InputPath) .\Main\buildVersion.h
 ProjDir=.
 TargetDir=\projects\generals\production\Run
@@ -146,7 +146,7 @@ InputPath=.\Main\generatedVersion.h
 !ELSEIF  "$(CFG)" == "RTS - Win32 Debug"
 
 # PROP Ignore_Default_Tool 1
-USERDEP__GENER="$(ProjDir)\main\winmain.cpp"	"$(ProjDir)\main\winmain.h"	"$(ProjDir)\Libraries\Lib\WW3D2Debug.lib"	"$(ProjDir)\Libraries\Lib\WWDebugDebug.lib"	"$(ProjDir)\Libraries\Lib\WWUtilDebug.lib"	"$(ProjDir)\Libraries\Lib\WWLibDebug.lib"	"$(ProjDir)\Libraries\Lib\WWMathDebug.lib"	"$(ProjDir)\GameEngine\Lib\GameEngineDebug.lib"	"$(ProjDir)\GameEngineDevice\Lib\GameEngineDeviceDebug.lib"	
+USERDEP__GENER="$(ProjDir)\SFMLPlatform\Main.cpp"	"$(ProjDir)\main\EntryPointLifecycle.cpp"	"$(ProjDir)\main\winmain.h"	"$(ProjDir)\Libraries\Lib\WW3D2Debug.lib"	"$(ProjDir)\Libraries\Lib\WWDebugDebug.lib"	"$(ProjDir)\Libraries\Lib\WWUtilDebug.lib"	"$(ProjDir)\Libraries\Lib\WWLibDebug.lib"	"$(ProjDir)\Libraries\Lib\WWMathDebug.lib"	"$(ProjDir)\GameEngine\Lib\GameEngineDebug.lib"	"$(ProjDir)\GameEngineDevice\Lib\GameEngineDeviceDebug.lib"	
 # Begin Custom Build - Incrementing version numbers held in $(InputPath) .\Main\buildVersion.h
 ProjDir=.
 TargetDir=\projects\generals\production\Run
@@ -161,7 +161,7 @@ InputPath=.\Main\generatedVersion.h
 !ELSEIF  "$(CFG)" == "RTS - Win32 Internal"
 
 # PROP Ignore_Default_Tool 1
-USERDEP__GENER="$(ProjDir)\main\winmain.cpp"	"$(ProjDir)\main\winmain.h"	"$(ProjDir)\Libraries\Lib\WW3D2Internal.lib"	"$(ProjDir)\Libraries\Lib\WWDebugInternal.lib"	"$(ProjDir)\Libraries\Lib\WWUtilInternal.lib"	"$(ProjDir)\Libraries\Lib\WWLibInternal.lib"	"$(ProjDir)\Libraries\Lib\WWMathInternal.lib"	"$(ProjDir)\GameEngine\Lib\GameEngineInternal.lib"	"$(ProjDir)\GameEngineDevice\Lib\GameEngineDeviceInternal.lib"	
+USERDEP__GENER="$(ProjDir)\SFMLPlatform\Main.cpp"	"$(ProjDir)\main\EntryPointLifecycle.cpp"	"$(ProjDir)\main\winmain.h"	"$(ProjDir)\Libraries\Lib\WW3D2Internal.lib"	"$(ProjDir)\Libraries\Lib\WWDebugInternal.lib"	"$(ProjDir)\Libraries\Lib\WWUtilInternal.lib"	"$(ProjDir)\Libraries\Lib\WWLibInternal.lib"	"$(ProjDir)\Libraries\Lib\WWMathInternal.lib"	"$(ProjDir)\GameEngine\Lib\GameEngineInternal.lib"	"$(ProjDir)\GameEngineDevice\Lib\GameEngineDeviceInternal.lib"	
 # Begin Custom Build - Incrementing version numbers held in $(InputPath) .\Main\buildVersion.h
 ProjDir=.
 TargetDir=\projects\generals\production\Run
@@ -178,7 +178,15 @@ InputPath=.\Main\generatedVersion.h
 # End Source File
 # Begin Source File
 
-SOURCE=.\Main\WinMain.cpp
+SOURCE=.\Main\EntryPointLifecycle.cpp
+# End Source File
+# Begin Source File
+
+SOURCE=.\Main\EntryPointLifecycle.h
+# End Source File
+# Begin Source File
+
+SOURCE=.\SFMLPlatform\Main.cpp
 # End Source File
 # Begin Source File
 


### PR DESCRIPTION
## Summary
- factor the shared graphics backend, version, and memory initialization into reusable entry point helpers
- let both WinMain and the SFML bootstrap use the new helpers and register the SFML-specific game engine factory override
- update the build project to compile the SFML main instead of WinMain and include the new helper sources

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc6dd2c4088331a8db1748bc0ec848