### PR TITLE
Add cross-platform stubs for Windows-only dependencies

### DIFF
--- a/Generals/Code/Compat/Bink/bink.h
+++ b/Generals/Code/Compat/Bink/bink.h
@@ -1,0 +1,23 @@
+#pragma once
+
+// Minimal subset of the RAD Game Tools Bink API required to compile the
+// cross-platform build.  The real SDK is proprietary and only available on
+// Windows.  We provide lightweight stand-ins for the handle and a few helper
+// structures so that code can be compiled without the SDK.
+
+#ifndef _WIN32
+
+#include <cstdint>
+
+using HBINK = void*;
+
+struct BINKRECT
+{
+        std::int32_t Left;
+        std::int32_t Top;
+        std::int32_t Width;
+        std::int32_t Height;
+};
+
+#endif  // !_WIN32
+

--- a/Generals/Code/Compat/D3D/d3d8.h
+++ b/Generals/Code/Compat/D3D/d3d8.h
@@ -1,0 +1,48 @@
+#pragma once
+
+// Minimal Direct3D 8 compatibility declarations for non-Windows builds.
+// These definitions are sufficient to satisfy the subset of the legacy
+// Command & Conquer Generals headers that refer to Direct3D interfaces.
+// They intentionally do not provide any functionality beyond the type
+// declarations required for compilation.
+
+#ifndef _WIN32
+
+#include <cstdint>
+
+using HRESULT = long;
+using DWORD = std::uint32_t;
+using D3DCOLOR = std::uint32_t;
+
+struct IDirect3D8;
+struct IDirect3DDevice8;
+struct IDirect3DTexture8;
+struct IDirect3DSurface8;
+struct IDirect3DBaseTexture8;
+struct IDirect3DVertexBuffer8;
+struct IDirect3DIndexBuffer8;
+struct IDirect3DStateBlock8;
+struct IDirect3DVolumeTexture8;
+struct IDirect3DCubeTexture8;
+struct IDirect3DSwapChain8;
+
+using LPDIRECT3D8 = IDirect3D8*;
+using LPDIRECT3DDEVICE8 = IDirect3DDevice8*;
+using LPDIRECT3DTEXTURE8 = IDirect3DTexture8*;
+using LPDIRECT3DSURFACE8 = IDirect3DSurface8*;
+using LPDIRECT3DVERTEXBUFFER8 = IDirect3DVertexBuffer8*;
+using LPDIRECT3DINDEXBUFFER8 = IDirect3DIndexBuffer8*;
+using LPDIRECT3DSTATEBLOCK8 = IDirect3DStateBlock8*;
+using LPDIRECT3DVOLUMETEXTURE8 = IDirect3DVolumeTexture8*;
+using LPDIRECT3DCUBETEXTURE8 = IDirect3DCubeTexture8*;
+using LPDIRECT3DSWAPCHAIN8 = IDirect3DSwapChain8*;
+
+constexpr HRESULT D3D_OK = 0;
+constexpr HRESULT D3DERR_INVALIDCALL = -2005530516;      // 0x8876086C
+constexpr HRESULT D3DERR_DEVICELOST = -2005530520;       // 0x88760868
+constexpr HRESULT D3DERR_DEVICENOTRESET = -2005530519;   // 0x88760869
+constexpr HRESULT D3DERR_OUTOFVIDEOMEMORY = -2005532292; // 0x8876017C
+constexpr HRESULT D3DERR_NOTAVAILABLE = -2005530518;     // 0x8876086A
+
+#endif  // !_WIN32
+

--- a/Generals/Code/Compat/DirectInput/dinput.h
+++ b/Generals/Code/Compat/DirectInput/dinput.h
@@ -1,0 +1,25 @@
+#pragma once
+
+// Minimal DirectInput compatibility header for non-Windows builds.  Only the
+// types referenced by the Command & Conquer Generals headers are declared
+// here, enough to satisfy the compiler when the real DirectInput SDK is not
+// available.
+
+#ifndef _WIN32
+
+#include <cstdint>
+
+using LPDIRECTINPUT8 = void*;
+using LPDIRECTINPUTDEVICE8 = void*;
+
+struct DIDEVICEOBJECTDATA
+{
+        std::uint32_t dwOfs;
+        std::uint32_t dwData;
+        std::uint32_t dwTimeStamp;
+        std::uint32_t dwSequence;
+        std::uintptr_t uAppData;
+};
+
+#endif  // !_WIN32
+

--- a/Generals/Code/Compat/WW3D2/Render2DSentence.h
+++ b/Generals/Code/Compat/WW3D2/Render2DSentence.h
@@ -1,0 +1,22 @@
+#pragma once
+
+// Minimal placeholder for the legacy WW3D2 text rendering helper.  The real
+// implementation depends on Direct3D and other Windows-specific facilities,
+// which are not available in the cross-platform build.  The SFML bootstrap
+// only requires the type declarations in order to compile the headers that
+// reference Render2DSentenceClass.
+
+#ifndef _WIN32
+
+class Render2DSentenceClass
+{
+public:
+        Render2DSentenceClass() = default;
+        ~Render2DSentenceClass() = default;
+
+        void Reset() {}
+        void Release() {}
+};
+
+#endif  // !_WIN32
+

--- a/Generals/Code/Compat/WW3D2/WW3DFormat.h
+++ b/Generals/Code/Compat/WW3D2/WW3DFormat.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#ifndef _WIN32
+
+enum WW3DFormat
+{
+        WW3D_FORMAT_UNKNOWN = 0,
+};
+
+#endif  // !_WIN32
+

--- a/Generals/Code/GameEngine/Include/GameClient/VideoPlayer.h
+++ b/Generals/Code/GameEngine/Include/GameClient/VideoPlayer.h
@@ -49,7 +49,7 @@
 //           Includes                                                      
 //----------------------------------------------------------------------------
 
-#include <lib/BaseType.h>
+#include <Lib/BaseType.h>
 #include "WWMath/rect.h"
 #include "Common/SubsystemInterface.h"
 #include "Common/AsciiString.h"

--- a/Generals/Code/GameEngine/Include/GameNetwork/WOLBrowser/WebBrowser.h
+++ b/Generals/Code/GameEngine/Include/GameNetwork/WOLBrowser/WebBrowser.h
@@ -1,25 +1,25 @@
 /*
-**	Command & Conquer Generals(tm)
-**	Copyright 2025 Electronic Arts Inc.
+**      Command & Conquer Generals(tm)
+**      Copyright 2025 Electronic Arts Inc.
 **
-**	This program is free software: you can redistribute it and/or modify
-**	it under the terms of the GNU General Public License as published by
-**	the Free Software Foundation, either version 3 of the License, or
-**	(at your option) any later version.
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
 **
-**	This program is distributed in the hope that it will be useful,
-**	but WITHOUT ANY WARRANTY; without even the implied warranty of
-**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-**	GNU General Public License for more details.
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
 **
-**	You should have received a copy of the GNU General Public License
-**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 ////////////////////////////////////////////////////////////////////////////////
-//																																						//
-//  (c) 2001-2003 Electronic Arts Inc.																				//
-//																																						//
+//
+//  (c) 2001-2003 Electronic Arts Inc.
+//
 ////////////////////////////////////////////////////////////////////////////////
 
 /******************************************************************************
@@ -46,82 +46,120 @@
 #define __WEBBROWSER_H__
 
 #include "Common/SubsystemInterface.h"
-#include <atlbase.h>
-#include <windows.h>
 #include <Common/GameMemory.h>
-#include "EABrowserDispatch/BrowserDispatch.h"
-#include "FEBDispatch.h"
 
 class GameWindow;
 
+#ifdef _WIN32
+
+#include <atlbase.h>
+#include <windows.h>
+#include "EABrowserDispatch/BrowserDispatch.h"
+#include "FEBDispatch.h"
+
 class WebBrowserURL : public MemoryPoolObject
 {
-	MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( WebBrowserURL, "WebBrowserURL" )
+        MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( WebBrowserURL, "WebBrowserURL" )
 
 public:
 
-	WebBrowserURL();
-	// virtual destructor prototype defined by memory pool object
+        WebBrowserURL();
+        // virtual destructor prototype defined by memory pool object
 
-	const FieldParse *getFieldParse( void ) const { return m_URLFieldParseTable; }
+        const FieldParse *getFieldParse( void ) const { return m_URLFieldParseTable; }
 
-	AsciiString m_tag;
-	AsciiString m_url;
+        AsciiString m_tag;
+        AsciiString m_url;
 
-	WebBrowserURL *m_next;
+        WebBrowserURL *m_next;
 
-	static const FieldParse m_URLFieldParseTable[];		///< the parse table for INI definition
+        static const FieldParse m_URLFieldParseTable[];         ///< the parse table for INI definition
 
 };
 
 
 
 class WebBrowser :
-		public FEBDispatch<WebBrowser, IBrowserDispatch, &IID_IBrowserDispatch>,
-		public SubsystemInterface
-	{
-	public:
-		void init( void );
-		void reset( void );
-		void update( void );
+                public FEBDispatch<WebBrowser, IBrowserDispatch, &IID_IBrowserDispatch>,
+                public SubsystemInterface
+        {
+        public:
+                void init( void );
+                void reset( void );
+                void update( void );
 
-		// Create an instance of the embedded browser for Dune Emperor.
-		virtual Bool createBrowserWindow(char *tag, GameWindow *win) = 0;
-		virtual void closeBrowserWindow(GameWindow *win) = 0;
+                // Create an instance of the embedded browser for Dune Emperor.
+                virtual Bool createBrowserWindow(char *tag, GameWindow *win) = 0;
+                virtual void closeBrowserWindow(GameWindow *win) = 0;
 
-		WebBrowserURL *makeNewURL(AsciiString tag);
-		WebBrowserURL *findURL(AsciiString tag);
+                WebBrowserURL *makeNewURL(AsciiString tag);
+                WebBrowserURL *findURL(AsciiString tag);
 
-	protected:
-		// Protected to prevent direct construction via new, use CreateInstance() instead.
-		WebBrowser();
-		virtual ~WebBrowser();
+        protected:
+                // Protected to prevent direct construction via new, use CreateInstance() instead.
+                WebBrowser();
+                virtual ~WebBrowser();
 
-		// Protected to prevent copy and assignment
-		WebBrowser(const WebBrowser&);
-		const WebBrowser& operator=(const WebBrowser&);
+                // Protected to prevent copy and assignment
+                WebBrowser(const WebBrowser&);
+                const WebBrowser& operator=(const WebBrowser&);
 
-//		Bool RetrievePageURL(const char* page, char* url, int size);
-//		Bool RetrieveHTMLPath(char* path, int size);
+//              Bool RetrievePageURL(const char* page, char* url, int size);
+//              Bool RetrieveHTMLPath(char* path, int size);
 
-	protected:
-		ULONG mRefCount;
-		WebBrowserURL *m_urlList;
+        protected:
+                ULONG mRefCount;
+                WebBrowserURL *m_urlList;
 
-	//---------------------------------------------------------------------------
-	// IUnknown methods
-	//---------------------------------------------------------------------------
-	protected:
-		HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject);
-		ULONG STDMETHODCALLTYPE AddRef(void);
-		ULONG STDMETHODCALLTYPE Release(void);
+        //---------------------------------------------------------------------------
+        // IUnknown methods
+        //---------------------------------------------------------------------------
+        protected:
+                HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject);
+                ULONG STDMETHODCALLTYPE AddRef(void);
+                ULONG STDMETHODCALLTYPE Release(void);
 
-	//---------------------------------------------------------------------------
-	// IBrowserDispatch methods
-	//---------------------------------------------------------------------------
-	public:
-		STDMETHOD(TestMethod)(Int num1);
-	};
+        //---------------------------------------------------------------------------
+        // IBrowserDispatch methods
+        //---------------------------------------------------------------------------
+        public:
+                STDMETHOD(TestMethod)(Int num1);
+        };
 
 extern CComObject<WebBrowser> *TheWebBrowser;
+
+#else  // !_WIN32
+
+class WebBrowserURL : public MemoryPoolObject
+{
+        MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE( WebBrowserURL, "WebBrowserURL" )
+
+public:
+        WebBrowserURL() : m_next(NULL) {}
+
+        const FieldParse *getFieldParse( void ) const { return NULL; }
+
+        AsciiString m_tag;
+        AsciiString m_url;
+        WebBrowserURL *m_next;
+};
+
+class WebBrowser : public SubsystemInterface
+{
+public:
+        void init( void ) {}
+        void reset( void ) {}
+        void update( void ) {}
+
+        virtual Bool createBrowserWindow(char *, GameWindow *) { return FALSE; }
+        virtual void closeBrowserWindow(GameWindow *) {}
+
+        WebBrowserURL *makeNewURL(AsciiString) { return NULL; }
+        WebBrowserURL *findURL(AsciiString) { return NULL; }
+};
+
+extern WebBrowser *TheWebBrowser;
+
+#endif  // _WIN32
+
 #endif // __WEBBROWSER_H__

--- a/Generals/Code/Main/WinMain.h
+++ b/Generals/Code/Main/WinMain.h
@@ -34,11 +34,22 @@
 #define __WINMAIN_H_
 
 // SYSTEM INCLUDES ////////////////////////////////////////////////////////////
+#ifdef _WIN32
 #include <windows.h>
+#else
+using HINSTANCE = void *;
+using HWND = void *;
+using HDC = void *;
+using HGLRC = void *;
+#endif
 
 // USER INCLUDES //////////////////////////////////////////////////////////////
 #include "GraphicsBackend.h"
+#ifdef _WIN32
 #include "Win32Device/GameClient/Win32Mouse.h"
+#else
+class Win32Mouse;
+#endif
 
 // EXTERNAL ///////////////////////////////////////////////////////////////////
 extern HINSTANCE ApplicationHInstance;  ///< our application instance

--- a/Generals/Code/SFMLPlatform/Main.cpp
+++ b/Generals/Code/SFMLPlatform/Main.cpp
@@ -35,6 +35,10 @@
 
 using sfml_platform::WindowConfig;
 using sfml_platform::WindowSystem;
+using sfml_platform::GetActiveKeyboardBridge;
+using sfml_platform::GetActiveMouseBridge;
+
+extern Bool ApplicationIsWindowed;
 
 namespace {
 

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ TARGET      ?= $(BIN_DIR)/generals-sfml
 ESCAPED_INCLUDE_DIRS := $(shell find $(SRC_DIR) -type d -print | sed 's/ /\\ /g' | sort)
 INCLUDE_DIRS         := $(foreach dir,$(ESCAPED_INCLUDE_DIRS),-I$(dir))
 CPPFLAGS             += $(INCLUDE_DIRS)
+CPPFLAGS             += -DWW3D_BGFX_AVAILABLE=1
 
 # STLport ships in a nested "stlport" include directory, so add a convenience
 # include for it when present.

--- a/make/modules/GameEngineDevice.mk
+++ b/make/modules/GameEngineDevice.mk
@@ -10,6 +10,7 @@ $(shell python3 build_tools/generate_make_fragment.py \
         $(GAME_ENGINE_DEVICE_SOURCES_MK) \
         --variable-prefix=GAME_ENGINE_DEVICE \
         --exclude=MilesAudioDevice \
+        --exclude=VideoDevice \
         --exclude=W3DDevice \
         --exclude=Win32Device)
 


### PR DESCRIPTION
## Summary
- add lightweight compatibility headers that stub Direct3D, DirectInput, Bink, and WW3D2 types when building on non-Windows platforms
- skip the legacy VideoDevice sources and enable the bgfx renderer flag in the make configuration
- update WinMain, WebBrowser, and SFML bootstrap code to avoid unconditional Windows-specific includes and to reference the SFML bridges explicitly

## Testing
- `make -j4` *(fails: still depends on additional platform-specific behaviour, stops in SFMLPlatform/Main.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68cd00aa26b483318637b209fcf00ec4