### PR TITLE
Enhance SFML and bgfx integration

### DIFF
--- a/Generals/Code/Compat/Windows/atlbase.h
+++ b/Generals/Code/Compat/Windows/atlbase.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#ifndef _WIN32
+
+#include "windows_compat.h"
+
+namespace cnc::windows
+{
+class CComModule
+{
+public:
+    void Init(void*, HINSTANCE) {}
+    void Term() {}
+};
+
+class CComSingleThreadModel
+{
+};
+
+template <typename ThreadModel = CComSingleThreadModel>
+class CComObjectRootEx
+{
+public:
+    using _ThreadModel = ThreadModel;
+};
+
+template <typename Base>
+class CComObject : public Base
+{
+public:
+    using _BaseClass = Base;
+};
+
+template <typename Interface>
+class CComPtr
+{
+public:
+    CComPtr() : m_ptr(nullptr) {}
+    explicit CComPtr(Interface* ptr) : m_ptr(ptr) {}
+
+    ~CComPtr()
+    {
+        if (m_ptr)
+        {
+            m_ptr->Release();
+        }
+    }
+
+    Interface* operator->() const { return m_ptr; }
+    Interface** operator&() { return &m_ptr; }
+    Interface* get() const { return m_ptr; }
+    void reset(Interface* ptr = nullptr)
+    {
+        if (m_ptr)
+        {
+            m_ptr->Release();
+        }
+        m_ptr = ptr;
+    }
+
+private:
+    Interface* m_ptr;
+};
+
+template <typename Interface>
+class CComQIPtr
+{
+public:
+    CComQIPtr() : m_ptr(nullptr) {}
+    explicit CComQIPtr(Interface* ptr) : m_ptr(ptr) {}
+    explicit CComQIPtr(IUnknown* unknown)
+        : m_ptr(unknown ? static_cast<Interface*>(unknown) : nullptr)
+    {
+    }
+
+    Interface* operator->() const { return m_ptr; }
+    operator Interface*() const { return m_ptr; }
+
+private:
+    Interface* m_ptr;
+};
+
+template <class T, const IID* piid = nullptr, const CLSID* pclsid = nullptr>
+class CComCoClass
+{
+public:
+    using _CreatorClass = T;
+};
+
+} // namespace cnc::windows
+
+using cnc::windows::CComModule;
+using cnc::windows::CComObject;
+using cnc::windows::CComObjectRootEx;
+using cnc::windows::CComSingleThreadModel;
+using cnc::windows::CComCoClass;
+using cnc::windows::CComPtr;
+using cnc::windows::CComQIPtr;
+
+#define BEGIN_COM_MAP(x)
+#define COM_INTERFACE_ENTRY(x)
+#define COM_INTERFACE_ENTRY_AGGREGATE(iid, ptr)
+#define END_COM_MAP()
+
+#endif // !_WIN32
+

--- a/Generals/Code/Compat/Windows/windows_compat.h
+++ b/Generals/Code/Compat/Windows/windows_compat.h
@@ -1,0 +1,476 @@
+#pragma once
+
+#ifndef _WIN32
+
+#include <cstdint>
+#include <cstddef>
+#include <cstring>
+#include <cwchar>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <chrono>
+#include <initializer_list>
+#include <thread>
+#include <type_traits>
+#include <unistd.h>
+
+namespace cnc::windows
+{
+using BOOL = int;
+using BYTE = unsigned char;
+using UCHAR = unsigned char;
+using WORD = std::uint16_t;
+using DWORD = std::uint32_t;
+using QWORD = std::uint64_t;
+using SHORT = short;
+using USHORT = unsigned short;
+using INT = int;
+using UINT = unsigned int;
+using LONG = long;
+using ULONG = unsigned long;
+using LONGLONG = std::int64_t;
+using ULONGLONG = std::uint64_t;
+using DWORDLONG = std::uint64_t;
+using FLOAT = float;
+using DOUBLE = double;
+using HRESULT = long;
+using HANDLE = void*;
+using HINSTANCE = void*;
+using HWND = void*;
+using HDC = void*;
+using HGLRC = void*;
+using HMODULE = void*;
+using HBITMAP = void*;
+using HBRUSH = void*;
+using HFONT = void*;
+using HPALETTE = void*;
+using HICON = void*;
+using HMENU = void*;
+using HCURSOR = void*;
+using HGDIOBJ = void*;
+using HPEN = void*;
+using HKEY = void*;
+using LPVOID = void*;
+using LPCVOID = const void*;
+using LPBYTE = BYTE*;
+using LPSTR = char*;
+using LPCSTR = const char*;
+using LPWSTR = wchar_t*;
+using LPCWSTR = const wchar_t*;
+using LPTSTR = char*;
+using LPCTSTR = const char*;
+using LPBOOL = BOOL*;
+using LPWORD = WORD*;
+using LPDWORD = DWORD*;
+using WPARAM = std::uintptr_t;
+using LPARAM = std::intptr_t;
+using LRESULT = std::intptr_t;
+using SIZE_T = std::size_t;
+using ULONG_PTR = std::uintptr_t;
+using LONG_PTR = std::intptr_t;
+using DWORD_PTR = std::uintptr_t;
+using UINT_PTR = std::uintptr_t;
+using INT_PTR = std::intptr_t;
+using LCID = unsigned long;
+using DISPID = long;
+using OLECHAR = wchar_t;
+using LPOLESTR = OLECHAR*;
+using LPCOLESTR = const OLECHAR*;
+
+struct RECT
+{
+    LONG left;
+    LONG top;
+    LONG right;
+    LONG bottom;
+};
+
+struct POINT
+{
+    LONG x;
+    LONG y;
+};
+
+struct SIZE
+{
+    LONG cx;
+    LONG cy;
+};
+
+#define cnc_WINAPI
+#define cnc_CALLBACK
+#define cnc_APIENTRY
+
+inline void Sleep(DWORD milliseconds)
+{
+    std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
+}
+
+inline UINT timeBeginPeriod(UINT)
+{
+    return 0;
+}
+
+inline UINT timeEndPeriod(UINT)
+{
+    return 0;
+}
+
+inline DWORD timeGetTime()
+{
+    using namespace std::chrono;
+    return static_cast<DWORD>(duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count());
+}
+
+inline DWORD GetTickCount()
+{
+    return timeGetTime();
+}
+
+inline void ZeroMemory(void* destination, std::size_t size)
+{
+    std::memset(destination, 0, size);
+}
+
+inline void CopyMemory(void* destination, const void* source, std::size_t size)
+{
+    std::memcpy(destination, source, size);
+}
+
+inline void MoveMemory(void* destination, const void* source, std::size_t size)
+{
+    std::memmove(destination, source, size);
+}
+
+constexpr BOOL TRUE_VALUE = 1;
+constexpr BOOL FALSE_VALUE = 0;
+constexpr DWORD INFINITE = 0xffffffffu;
+constexpr DWORD MAX_PATH = 260;
+
+constexpr HRESULT S_OK = 0;
+constexpr HRESULT S_FALSE = 1;
+constexpr HRESULT E_FAIL = static_cast<HRESULT>(0x80004005L);
+constexpr HRESULT E_POINTER = static_cast<HRESULT>(0x80004003L);
+constexpr HRESULT E_OUTOFMEMORY = static_cast<HRESULT>(0x8007000EL);
+constexpr HRESULT E_NOTIMPL = static_cast<HRESULT>(0x80004001L);
+constexpr HRESULT E_NOINTERFACE = static_cast<HRESULT>(0x80004002L);
+
+inline bool SUCCEEDED(HRESULT value)
+{
+    return value >= 0;
+}
+
+inline bool FAILED(HRESULT value)
+{
+    return value < 0;
+}
+
+struct GUID
+{
+    std::uint32_t Data1;
+    std::uint16_t Data2;
+    std::uint16_t Data3;
+    std::uint8_t Data4[8];
+};
+
+using IID = GUID;
+using CLSID = GUID;
+
+#define cnc_DECLSPEC_UUID(uuid_string)
+
+#define cnc_REFCLSID const ::cnc::windows::CLSID&
+#define cnc_REFIID const ::cnc::windows::IID&
+#define cnc_REFGUID const ::cnc::windows::GUID&
+
+inline bool IsEqualGUID(cnc_REFGUID lhs, cnc_REFGUID rhs)
+{
+    return lhs.Data1 == rhs.Data1 && lhs.Data2 == rhs.Data2 && lhs.Data3 == rhs.Data3 &&
+           std::memcmp(lhs.Data4, rhs.Data4, sizeof(lhs.Data4)) == 0;
+}
+
+struct IUnknown
+{
+    virtual ~IUnknown() = default;
+    virtual HRESULT QueryInterface(cnc_REFIID, void**)
+    {
+        return E_NOINTERFACE;
+    }
+    virtual ULONG AddRef()
+    {
+        return 1;
+    }
+    virtual ULONG Release()
+    {
+        return 1;
+    }
+};
+
+struct IDispatch : public IUnknown
+{
+    virtual HRESULT GetTypeInfoCount(UINT*)
+    {
+        return E_NOTIMPL;
+    }
+    virtual HRESULT GetTypeInfo(UINT, LCID, void**)
+    {
+        return E_NOTIMPL;
+    }
+    virtual HRESULT GetIDsOfNames(cnc_REFIID, LPOLESTR*, UINT, LCID, DISPID*)
+    {
+        return E_NOTIMPL;
+    }
+    virtual HRESULT Invoke(DISPID, cnc_REFIID, LCID, unsigned short, void*, void*, void*, UINT*)
+    {
+        return E_NOTIMPL;
+    }
+};
+
+using LPDISPATCH = IDispatch*;
+using LPUNKNOWN = IUnknown*;
+
+using BSTR = wchar_t*;
+using VARIANT_BOOL = short;
+constexpr VARIANT_BOOL VARIANT_TRUE = -1;
+constexpr VARIANT_BOOL VARIANT_FALSE = 0;
+
+enum VARTYPE : std::uint16_t
+{
+    VT_EMPTY = 0,
+    VT_NULL = 1,
+    VT_I2 = 2,
+    VT_I4 = 3,
+    VT_R4 = 4,
+    VT_R8 = 5,
+    VT_CY = 6,
+    VT_DATE = 7,
+    VT_BSTR = 8,
+    VT_DISPATCH = 9,
+    VT_ERROR = 10,
+    VT_BOOL = 11,
+    VT_VARIANT = 12,
+    VT_UNKNOWN = 13,
+    VT_I1 = 16,
+    VT_UI1 = 17,
+    VT_UI2 = 18,
+    VT_UI4 = 19,
+    VT_I8 = 20,
+    VT_UI8 = 21,
+    VT_INT = 22,
+    VT_UINT = 23,
+};
+
+struct VARIANT
+{
+    VARTYPE vt;
+    std::uint16_t wReserved1;
+    std::uint16_t wReserved2;
+    std::uint16_t wReserved3;
+    union
+    {
+        LONGLONG llVal;
+        LONG lVal;
+        BYTE bVal;
+        SHORT iVal;
+        FLOAT fltVal;
+        DOUBLE dblVal;
+        VARIANT_BOOL boolVal;
+        BSTR bstrVal;
+        IUnknown* punkVal;
+        IDispatch* pdispVal;
+        void* byref;
+    } n1;
+
+    VARIANT() : vt(VT_EMPTY), wReserved1(0), wReserved2(0), wReserved3(0)
+    {
+        n1.byref = nullptr;
+    }
+};
+
+inline void VariantInit(VARIANT* value)
+{
+    if (value)
+    {
+        *value = VARIANT{};
+    }
+}
+
+inline void VariantClear(VARIANT* value)
+{
+    if (!value)
+    {
+        return;
+    }
+
+    if (value->vt == VT_BSTR && value->n1.bstrVal)
+    {
+        delete[] value->n1.bstrVal;
+    }
+
+    value->vt = VT_EMPTY;
+    value->n1.byref = nullptr;
+}
+
+inline int lstrcmpiA(LPCSTR left, LPCSTR right)
+{
+    return ::strcasecmp(left, right);
+}
+
+inline int lstrlenA(LPCSTR value)
+{
+    return static_cast<int>(std::strlen(value));
+}
+
+inline void OutputDebugStringA(LPCSTR message)
+{
+    if (message)
+    {
+        std::fprintf(stderr, "%s", message);
+    }
+}
+
+inline DWORD GetLastError()
+{
+    return 0;
+}
+
+inline void SetLastError(DWORD)
+{
+}
+
+} // namespace cnc::windows
+
+using cnc::windows::BOOL;
+using cnc::windows::BYTE;
+using cnc::windows::UCHAR;
+using cnc::windows::WORD;
+using cnc::windows::DWORD;
+using cnc::windows::QWORD;
+using cnc::windows::SHORT;
+using cnc::windows::USHORT;
+using cnc::windows::INT;
+using cnc::windows::UINT;
+using cnc::windows::LONG;
+using cnc::windows::ULONG;
+using cnc::windows::LONGLONG;
+using cnc::windows::ULONGLONG;
+using cnc::windows::FLOAT;
+using cnc::windows::DOUBLE;
+using cnc::windows::HRESULT;
+using cnc::windows::HANDLE;
+using cnc::windows::HINSTANCE;
+using cnc::windows::HWND;
+using cnc::windows::HDC;
+using cnc::windows::HGLRC;
+using cnc::windows::HMODULE;
+using cnc::windows::HBITMAP;
+using cnc::windows::HBRUSH;
+using cnc::windows::HFONT;
+using cnc::windows::HPALETTE;
+using cnc::windows::HICON;
+using cnc::windows::HMENU;
+using cnc::windows::HCURSOR;
+using cnc::windows::HGDIOBJ;
+using cnc::windows::HPEN;
+using cnc::windows::HKEY;
+using cnc::windows::LPVOID;
+using cnc::windows::LPCVOID;
+using cnc::windows::LPBYTE;
+using cnc::windows::LPSTR;
+using cnc::windows::LPCSTR;
+using cnc::windows::LPWSTR;
+using cnc::windows::LPCWSTR;
+using cnc::windows::LPTSTR;
+using cnc::windows::LPCTSTR;
+using cnc::windows::LPBOOL;
+using cnc::windows::LPWORD;
+using cnc::windows::LPDWORD;
+using cnc::windows::WPARAM;
+using cnc::windows::LPARAM;
+using cnc::windows::LRESULT;
+using cnc::windows::SIZE_T;
+using cnc::windows::ULONG_PTR;
+using cnc::windows::LONG_PTR;
+using cnc::windows::DWORD_PTR;
+using cnc::windows::UINT_PTR;
+using cnc::windows::INT_PTR;
+using cnc::windows::LCID;
+using cnc::windows::DISPID;
+using cnc::windows::OLECHAR;
+using cnc::windows::LPOLESTR;
+using cnc::windows::LPCOLESTR;
+using cnc::windows::RECT;
+using cnc::windows::POINT;
+using cnc::windows::SIZE;
+using cnc::windows::GUID;
+using cnc::windows::IID;
+using cnc::windows::CLSID;
+using cnc::windows::IUnknown;
+using cnc::windows::IDispatch;
+using cnc::windows::LPDISPATCH;
+using cnc::windows::LPUNKNOWN;
+using cnc::windows::BSTR;
+using cnc::windows::VARIANT_BOOL;
+using cnc::windows::VARIANT;
+using cnc::windows::VARTYPE;
+
+using cnc::windows::TRUE_VALUE;
+using cnc::windows::FALSE_VALUE;
+using cnc::windows::INFINITE;
+using cnc::windows::MAX_PATH;
+using cnc::windows::S_OK;
+using cnc::windows::S_FALSE;
+using cnc::windows::E_FAIL;
+using cnc::windows::E_POINTER;
+using cnc::windows::E_OUTOFMEMORY;
+using cnc::windows::E_NOTIMPL;
+using cnc::windows::E_NOINTERFACE;
+using cnc::windows::VARIANT_TRUE;
+using cnc::windows::VARIANT_FALSE;
+
+using cnc::windows::Sleep;
+using cnc::windows::timeBeginPeriod;
+using cnc::windows::timeEndPeriod;
+using cnc::windows::timeGetTime;
+using cnc::windows::GetTickCount;
+using cnc::windows::ZeroMemory;
+using cnc::windows::CopyMemory;
+using cnc::windows::MoveMemory;
+using cnc::windows::SUCCEEDED;
+using cnc::windows::FAILED;
+using cnc::windows::IsEqualGUID;
+using cnc::windows::VariantInit;
+using cnc::windows::VariantClear;
+using cnc::windows::lstrcmpiA;
+using cnc::windows::lstrlenA;
+using cnc::windows::OutputDebugStringA;
+using cnc::windows::GetLastError;
+using cnc::windows::SetLastError;
+
+#define WINAPI cnc_WINAPI
+#define CALLBACK cnc_CALLBACK
+#define APIENTRY cnc_APIENTRY
+#define STDMETHODCALLTYPE
+#define STDAPICALLTYPE
+#define STDMETHODIMP HRESULT
+#define STDMETHODIMP_(type) type
+#define STDMETHOD(method) virtual HRESULT STDMETHODCALLTYPE method
+#define STDMETHOD_(type, method) virtual type STDMETHODCALLTYPE method
+#define STDMETHODCALLTYPE
+#define DECLSPEC_UUID(x) cnc_DECLSPEC_UUID(x)
+#define REFGUID cnc_REFGUID
+#define REFIID cnc_REFIID
+#define REFCLSID cnc_REFCLSID
+
+#define INVALID_HANDLE_VALUE reinterpret_cast<HANDLE>(static_cast<std::intptr_t>(-1))
+
+#define LOWORD(l) static_cast<WORD>(static_cast<DWORD_PTR>(l) & 0xffff)
+#define HIWORD(l) static_cast<WORD>((static_cast<DWORD_PTR>(l) >> 16) & 0xffff)
+#define LOBYTE(w) static_cast<BYTE>(static_cast<DWORD_PTR>(w) & 0xff)
+#define HIBYTE(w) static_cast<BYTE>((static_cast<DWORD_PTR>(w) >> 8) & 0xff)
+
+#define MAKELONG(a, b) static_cast<LONG>((static_cast<DWORD>(static_cast<WORD>(a)) & 0xffff) | (static_cast<DWORD>(static_cast<WORD>(b)) << 16))
+#define MAKEWORD(a, b) static_cast<WORD>((static_cast<BYTE>(a) & 0xff) | ((static_cast<WORD>(static_cast<BYTE>(b)) & 0xff) << 8))
+
+#endif // !_WIN32
+

--- a/Generals/Code/GameEngine/Include/Common/GlobalData.h
+++ b/Generals/Code/GameEngine/Include/Common/GlobalData.h
@@ -39,6 +39,9 @@
 #include "Common/SubsystemInterface.h"
 #include "GameClient/Color.h"
 #include "Common/STLTypedefs.h"
+#include "GameClient/TerrainVisual.h"
+#include "GameLogic/Module/BodyModule.h"
+#include "GameLogic/AI.h"
 
 // FORWARD DECLARATIONS ///////////////////////////////////////////////////////////////////////////
 struct FieldParse;

--- a/Generals/Code/GameEngine/Include/Common/SubsystemInterface.h
+++ b/Generals/Code/GameEngine/Include/Common/SubsystemInterface.h
@@ -33,7 +33,8 @@
 #define __SUBSYSTEMINTERFACE_H_
 
 #include "Common/INI.h"
-#include "Common/STLTypedefs.h"	
+#include "Common/STLTypedefs.h"
+#include <vector>
 
 class Xfer;
 

--- a/Generals/Code/GameEngine/Include/Common/file.h
+++ b/Generals/Code/GameEngine/Include/Common/file.h
@@ -52,7 +52,7 @@
 //           Includes                                                      
 //----------------------------------------------------------------------------
 
-#include "lib/basetype.h"
+#include "Lib/BaseType.h"
 #include "Common/AsciiString.h"
 #include "Common/GameMemory.h"
 // include FileSystem.h as it will be used alot with File.h
@@ -129,15 +129,15 @@ class File : public MemoryPoolObject
 		virtual Bool	open( const Char *filename, Int access = 0 );				///< Open a file for access
 		virtual void	close( void );																			///< Close the file !!! File object no longer valid after this call !!!
 
-		virtual Int		read( void *buffer, Int bytes ) = NULL ;						/**< Read the specified number of bytes from the file in to the 
+		virtual Int		read( void *buffer, Int bytes ) = 0;						/**< Read the specified number of bytes from the file in to the 
 																																			  *  memory pointed at by buffer. Returns the number of bytes read.
 																																			  *  Returns -1 if an error occured.
 																																			  */
-		virtual Int		write( const void *buffer, Int bytes ) = NULL ;						/**< Write the specified number of bytes from the    
+		virtual Int		write( const void *buffer, Int bytes ) = 0;						/**< Write the specified number of bytes from the    
 																																			  *	 memory pointed at by buffer to the file. Returns the number of bytes written.
 																																			  *	 Returns -1 if an error occured.
 																																			  */
-		virtual Int		seek( Int bytes, seekMode mode = CURRENT ) = NULL;	/**< Sets the file position of the next read/write operation. Returns the new file
+		virtual Int		seek( Int bytes, seekMode mode = CURRENT ) = 0;	/**< Sets the file position of the next read/write operation. Returns the new file
 																																				*  position as the number of bytes from the start of the file.
 																																				*  Returns -1 if an error occured.
 																																				*

--- a/Generals/Code/GameEngine/Include/GameLogic/AI.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/AI.h
@@ -35,8 +35,14 @@
 #include "Common/SubsystemInterface.h"
 #include "Common/GameMemory.h"
 #include "Common/GameType.h"
+#include "Common/SpecialPowerType.h"
+#include "Common/Upgrade.h"
+#include "GameClient/ControlBar.h"
 #include "GameLogic/Damage.h"
 #include "GameLogic/HackerAttackMode.h"
+#include "GameLogic/WeaponSet.h"
+#include "GameLogic/WeaponSetType.h"
+#include "GameLogic/Module/BattlePlanUpdate.h"
 #include "Common/STLTypedefs.h"
 
 class AIGroup;

--- a/Generals/Code/GameEngine/Include/GameNetwork/WOLBrowser/FEBDispatch.h
+++ b/Generals/Code/GameEngine/Include/GameNetwork/WOLBrowser/FEBDispatch.h
@@ -30,27 +30,33 @@
 #ifndef _FEBDISPATCH_H__
 #define _FEBDISPATCH_H__
 
+#ifdef _WIN32
 #include <atlbase.h>
 extern CComModule _Module;
 #include <atlcom.h>
 #include <comutil.h>    // For _bstr_t.
-
 #include "oleauto.h"
+#endif
 
 template <class T, class C, const IID *I>
 class FEBDispatch :
+#ifdef _WIN32
 public CComObjectRootEx<CComSingleThreadModel>,
 public CComCoClass<T>,
 public C
+#else
+public C
+#endif
 {
 public:
-	
-	BEGIN_COM_MAP(T)
-		COM_INTERFACE_ENTRY(C)
-		COM_INTERFACE_ENTRY_AGGREGATE(IID_IDispatch, m_dispatch)
-	END_COM_MAP()
-		
-		FEBDispatch()
+
+#ifdef _WIN32
+        BEGIN_COM_MAP(T)
+                COM_INTERFACE_ENTRY(C)
+                COM_INTERFACE_ENTRY_AGGREGATE(IID_IDispatch, m_dispatch)
+        END_COM_MAP()
+
+                FEBDispatch()
 	{
 		m_ptinfo = NULL;
 		m_dispatch = NULL;
@@ -95,12 +101,21 @@ public:
 		
 		if (m_dispatch)
 			m_dispatch->Release();
-	}
-	
-	IUnknown *m_dispatch;
+        }
+
+        IUnknown *m_dispatch;
 
 private:
-	ITypeInfo *m_ptinfo;
+        ITypeInfo *m_ptinfo;
+#else
+        FEBDispatch()
+        {
+        }
+
+        ~FEBDispatch()
+        {
+        }
+#endif
 };
 
 #endif

--- a/Generals/Code/GameEngine/Include/Precompiled/PreRTS.h
+++ b/Generals/Code/GameEngine/Include/Precompiled/PreRTS.h
@@ -40,23 +40,16 @@ class STLSpecialAlloc;
 // different .cpp files, so I bit the bullet and included it here.
 // PLEASE DO NOT ABUSE WINDOWS OR IT WILL BE REMOVED ENTIRELY. :-)
 //--------------------------------------------------------------------------------- System Includes 
+#ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <atlbase.h>
 #include <windows.h>
-
-#include <assert.h>
-#include <ctype.h>
 #include <direct.h>
 #include <EXCPT.H>
-#include <float.h>
-#include <fstream>
 #include <imagehlp.h>
 #include <io.h>
-#include <limits.h>
 #include <lmcons.h>
 #include <mapicode.h>
-#include <math.h>
-#include <cstring>
 #include <mmsystem.h>
 #include <objbase.h>
 #include <ocidl.h>
@@ -65,26 +58,48 @@ class STLSpecialAlloc;
 #include <shlobj.h>
 #include <shlguid.h>
 #include <snmp.h>
+#include <tchar.h>
+#include <vfw.h>
+#include <winerror.h>
+#include <wininet.h>
+#include <winreg.h>
+#else
+#include "Compat/Windows/atlbase.h"
+#include "Compat/Windows/windows_compat.h"
+#include <unistd.h>
+#endif
+
+#include <assert.h>
+#include <ctype.h>
+#include <float.h>
+#include <fstream>
+#include <limits.h>
+#include <math.h>
+#include <cstring>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <sys/timeb.h>
 #include <sys/types.h>
-#include <TCHAR.H>
 #include <time.h>
-#include <vfw.h>
-#include <winerror.h>
-#include <wininet.h>
-#include <winreg.h>
+
+#ifdef _WIN32
+#include <sys/timeb.h>
+#else
+#include <sys/time.h>
+#endif
 
 #ifndef DIRECTINPUT_VERSION
 #	define DIRECTINPUT_VERSION	0x800
 #endif
 
+#ifdef _WIN32
 #include <dinput.h>
+#else
+#include "Compat/DirectInput/dinput.h"
+#endif
 
 //------------------------------------------------------------------------------------ STL Includes
 // srj sez: no, include STLTypesdefs below, instead, thanks
@@ -101,7 +116,7 @@ class STLSpecialAlloc;
 
 //------------------------------------------------------------------------------------ RTS Includes
 // Icky. These have to be in this order.
-#include "Lib/Basetype.h"
+#include "Lib/BaseType.h"
 #include "Common/STLTypedefs.h"
 #include "Common/Errors.h"
 #include "Common/Debug.h"

--- a/Generals/Code/GameEngine/Source/Common/Audio/AudioEventRTS.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Audio/AudioEventRTS.cpp
@@ -43,7 +43,7 @@
 #include "Common/AudioEventInfo.h"
 #include "Common/AudioRandomValue.h"
 #include "Common/AudioSettings.h"
-#include "Common/File.h"
+#include "Common/file.h"
 #include "Common/FileSystem.h"
 #include "Common/GameSounds.h"
 #include "Common/GlobalData.h"

--- a/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
+++ b/Generals/Code/GameEngine/Source/Common/GameEngine.cpp
@@ -172,6 +172,9 @@ void initSubsystem(SUBSYSTEM*& sysref, AsciiString name, SUBSYSTEM* sys, Xfer *p
 //-------------------------------------------------------------------------------------------------
 extern HINSTANCE ApplicationHInstance;  ///< our application instance
 extern CComModule _Module;
+#ifndef _WIN32
+CComModule _Module;
+#endif
 
 //-------------------------------------------------------------------------------------------------
 static void updateTGAtoDDS();

--- a/Generals/Code/GameEngine/Source/GameNetwork/WOLBrowser/WebBrowser.cpp
+++ b/Generals/Code/GameEngine/Source/GameNetwork/WOLBrowser/WebBrowser.cpp
@@ -46,6 +46,8 @@
 #include "GameClient/GameWindow.h"
 #include "GameClient/Display.h"
 
+#ifdef _WIN32
+
 #ifdef _INTERNAL
 // for occasional debugging...
 //#pragma optimize("", off)
@@ -308,8 +310,14 @@ ULONG STDMETHODCALLTYPE WebBrowser::Release(void)
 	return mRefCount;
 }
 
-STDMETHODIMP WebBrowser::TestMethod(Int num1) 
+STDMETHODIMP WebBrowser::TestMethod(Int num1)
 {
-	DEBUG_LOG(("WebBrowser::TestMethod - num1 = %d\n", num1));
-	return S_OK;
+        DEBUG_LOG(("WebBrowser::TestMethod - num1 = %d\n", num1));
+        return S_OK;
 }
+
+#else  // !_WIN32
+
+WebBrowser *TheWebBrowser = NULL;
+
+#endif  // _WIN32

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/dx8wrapper.cpp
@@ -74,6 +74,7 @@
 #include "dx8texman.h"
 #include "bound.h"
 #include "dx8webbrowser.h"
+#include "Main/WinMain.h"
 
 #ifndef WW3D_BGFX_AVAILABLE
 #define WW3D_BGFX_AVAILABLE 0
@@ -283,10 +284,12 @@ static void PopulateBgfxDeviceDescriptions()
 static bool InitializeBgfx(void* hwnd)
 {
 #if WW3D_BGFX_AVAILABLE
-        g_bgfxState.windowHandle = hwnd;
+        void* windowHandle = ApplicationBgfxNativeWindow.window != NULL ?
+                ApplicationBgfxNativeWindow.window : hwnd;
+        g_bgfxState.windowHandle = windowHandle;
         g_bgfxState.initialized = false;
 
-        _Hwnd = (HWND)hwnd;
+        _Hwnd = (HWND)windowHandle;
         _MainThreadID = ThreadClass::_Get_Current_Thread_ID();
         CurRenderDevice = -1;
         ResolutionWidth = DEFAULT_RESOLUTION_WIDTH;
@@ -307,7 +310,12 @@ static bool InitializeBgfx(void* hwnd)
 
         bgfx::PlatformData platformData;
         ::memset(&platformData, 0, sizeof(platformData));
-        platformData.nwh = hwnd;
+        platformData.ndt = ApplicationBgfxNativeWindow.display;
+        platformData.nwh = windowHandle;
+        platformData.context = ApplicationBgfxNativeWindow.context;
+        platformData.backBuffer = ApplicationBgfxNativeWindow.backBuffer;
+        platformData.backBufferDS = ApplicationBgfxNativeWindow.backBufferDepth;
+        platformData.destroyWindow = ApplicationBgfxNativeWindow.destroyWindow;
         bgfx::setPlatformData(platformData);
 
         bgfx::Init initArgs;

--- a/Generals/Code/Main/ApplicationGlobals.cpp
+++ b/Generals/Code/Main/ApplicationGlobals.cpp
@@ -27,6 +27,7 @@ Bool ApplicationIsWindowed = false;
 GraphicsBackend ApplicationGraphicsBackend = GRAPHICS_BACKEND_DIRECT3D8;
 Win32Mouse* TheWin32Mouse = NULL;
 DWORD TheMessageTime = 0;
+BgfxNativeWindowData ApplicationBgfxNativeWindow;
 
 const Char* g_strFile = "data\\Generals.str";
 const Char* g_csfFile = "data\\%s\\Generals.csf";

--- a/Generals/Code/Main/WinMain.h
+++ b/Generals/Code/Main/WinMain.h
@@ -62,6 +62,28 @@ extern Win32Mouse *TheWin32Mouse;  ///< global for win32 mouse only!
 extern DWORD TheMessageTime;       ///< For getting the time that a message was posted from Windows.
 extern Bool gInitialEngineActiveState;
 
+struct BgfxNativeWindowData
+{
+        void *display;
+        void *window;
+        void *context;
+        void *backBuffer;
+        void *backBufferDepth;
+        void (*destroyWindow)(void *);
+
+        BgfxNativeWindowData()
+                : display(NULL),
+                  window(NULL),
+                  context(NULL),
+                  backBuffer(NULL),
+                  backBufferDepth(NULL),
+                  destroyWindow(NULL)
+        {
+        }
+};
+
+extern BgfxNativeWindowData ApplicationBgfxNativeWindow;
+
 #ifdef _WIN32
 LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam);
 #endif

--- a/Generals/Code/SFMLPlatform/Main.cpp
+++ b/Generals/Code/SFMLPlatform/Main.cpp
@@ -37,6 +37,7 @@ using sfml_platform::WindowConfig;
 using sfml_platform::WindowSystem;
 using sfml_platform::GetActiveKeyboardBridge;
 using sfml_platform::GetActiveMouseBridge;
+using sfml_platform::NativeWindowHandle;
 
 extern Bool ApplicationIsWindowed;
 
@@ -376,13 +377,20 @@ int main(int argc, char** argv) {
         return 1;
     }
 
+    const NativeWindowHandle nativeHandle = windowSystem.nativeHandle();
+
 #ifdef _WIN32
     ApplicationHInstance = GetModuleHandle(nullptr);
-    ApplicationHWnd = reinterpret_cast<HWND>(windowSystem.window().getSystemHandle());
 #else
     ApplicationHInstance = nullptr;
-    ApplicationHWnd = nullptr;
 #endif
+    ApplicationHWnd = reinterpret_cast<HWND>(nativeHandle.window);
+    ApplicationBgfxNativeWindow.display = nativeHandle.display;
+    ApplicationBgfxNativeWindow.window = nativeHandle.window;
+    ApplicationBgfxNativeWindow.context = nativeHandle.context;
+    ApplicationBgfxNativeWindow.backBuffer = nativeHandle.backBuffer;
+    ApplicationBgfxNativeWindow.backBufferDepth = nativeHandle.backBufferDepth;
+    ApplicationBgfxNativeWindow.destroyWindow = nativeHandle.destroyWindow;
     ApplicationIsWindowed = !parsed.config.fullscreen;
     gInitialEngineActiveState = windowSystem.window().hasFocus() ? TRUE : FALSE;
     g_activeWindowSystem = &windowSystem;

--- a/Generals/Code/SFMLPlatform/WindowSystem.h
+++ b/Generals/Code/SFMLPlatform/WindowSystem.h
@@ -7,6 +7,15 @@
 
 namespace sfml_platform {
 
+struct NativeWindowHandle {
+    void* display = nullptr;
+    void* window = nullptr;
+    void* context = nullptr;
+    void* backBuffer = nullptr;
+    void* backBufferDepth = nullptr;
+    void (*destroyWindow)(void*) = nullptr;
+};
+
 class WindowSystem {
 public:
     using EventHandler = std::function<void(const sf::Event&)>;
@@ -22,6 +31,8 @@ public:
 
     sf::RenderWindow& window();
     const sf::RenderWindow& window() const;
+
+    NativeWindowHandle nativeHandle() const;
 
 private:
     void configureRenderSettings(const WindowConfig& config);


### PR DESCRIPTION
## Summary
- add minimal Win32 and ATL compatibility headers so non-Windows builds can satisfy legacy interfaces
- expose SFML native window handles through the window system and store them in the application globals
- initialize the bgfx backend with the SFML-provided handles to allow cross-platform rendering startup

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68cd1c3344888331a0e51f324c6ddb4c