### PR TITLE
Refactor SFML engine loop and add platform-neutral file systems

### DIFF
--- a/Generals/Code/GameEngineDevice/Include/SfmlDevice/Common/SfmlBIGFile.h
+++ b/Generals/Code/GameEngineDevice/Include/SfmlDevice/Common/SfmlBIGFile.h
@@ -1,0 +1,54 @@
+/*
+**      Command & Conquer Generals(tm)
+**      Copyright 2025 Electronic Arts Inc.
+**
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
+**
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
+**
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  (c) 2001-2003 Electronic Arts Inc.                                        //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+// FILE: SfmlBIGFile.h /////////////////////////////////////////////////////////
+// Author: OpenAI Assistant, 2025
+// Description:
+//   ArchiveFile implementation for BIG archives used by the SFML device layer.
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#ifndef __SFMLBIGFILE_H
+#define __SFMLBIGFILE_H
+
+#include "Common/ArchiveFile.h"
+
+class SfmlBIGFile : public ArchiveFile
+{
+        MEMORY_POOL_GLUE_WITH_USERLOOKUP_CREATE(SfmlBIGFile, "SfmlBIGFile")
+public:
+        SfmlBIGFile();
+        virtual ~SfmlBIGFile();
+
+        virtual File* openFile(const Char* filename, Int access = 0);
+        virtual void closeAllFiles(void);
+        virtual AsciiString getName(void);
+        virtual AsciiString getPath(void);
+        virtual void setSearchPriority(Int new_priority);
+        virtual void close(void);
+        virtual Bool getFileInfo(const AsciiString& filename, FileInfo* fileInfo) const;
+};
+
+#endif // __SFMLBIGFILE_H

--- a/Generals/Code/GameEngineDevice/Include/SfmlDevice/Common/SfmlBIGFileSystem.h
+++ b/Generals/Code/GameEngineDevice/Include/SfmlDevice/Common/SfmlBIGFileSystem.h
@@ -1,0 +1,58 @@
+/*
+**      Command & Conquer Generals(tm)
+**      Copyright 2025 Electronic Arts Inc.
+**
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
+**
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
+**
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  (c) 2001-2003 Electronic Arts Inc.                                        //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+// FILE: SfmlBIGFileSystem.h ///////////////////////////////////////////////////
+// Author: OpenAI Assistant, 2025
+// Description:
+//   Platform-neutral BIG archive file system implementation used by the SFML
+//   device layer.
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#ifndef __SFMLBIGFILESYSTEM_H
+#define __SFMLBIGFILESYSTEM_H
+
+#include "Common/ArchiveFileSystem.h"
+
+class SfmlBIGFileSystem : public ArchiveFileSystem
+{
+public:
+        SfmlBIGFileSystem();
+        virtual ~SfmlBIGFileSystem();
+
+        virtual void init(void);
+        virtual void update(void);
+        virtual void reset(void);
+        virtual void postProcessLoad(void);
+
+        virtual ArchiveFile* openArchiveFile(const Char* filename);
+        virtual void closeArchiveFile(const Char* filename);
+        virtual void closeAllArchiveFiles(void);
+        virtual void closeAllFiles(void);
+
+        virtual Bool loadBigFilesFromDirectory(AsciiString dir, AsciiString fileMask, Bool overwrite = FALSE);
+};
+
+#endif // __SFMLBIGFILESYSTEM_H

--- a/Generals/Code/GameEngineDevice/Include/SfmlDevice/Common/SfmlGameEngine.h
+++ b/Generals/Code/GameEngineDevice/Include/SfmlDevice/Common/SfmlGameEngine.h
@@ -35,18 +35,38 @@
 #ifndef __SFMLGAMEENGINE_H_
 #define __SFMLGAMEENGINE_H_
 
-#include "Win32Device/Common/Win32GameEngine.h"
+#include "Common/GameEngine.h"
 
-class SfmlGameEngine : public Win32GameEngine
+namespace sf
+{
+        class Event;
+}
+
+class SfmlGameEngine : public GameEngine
 {
 public:
         SfmlGameEngine();
         virtual ~SfmlGameEngine();
 
-        virtual void update( void );
+        virtual void execute(void);
+        virtual void update(void);
 
 protected:
-        virtual void serviceWindowsOS( void );
+        virtual GameLogic* createGameLogic(void);
+        virtual GameClient* createGameClient(void);
+        virtual ModuleFactory* createModuleFactory(void);
+        virtual ThingFactory* createThingFactory(void);
+        virtual FunctionLexicon* createFunctionLexicon(void);
+        virtual LocalFileSystem* createLocalFileSystem(void);
+        virtual ArchiveFileSystem* createArchiveFileSystem(void);
+        virtual NetworkInterface* createNetwork(void);
+        virtual Radar* createRadar(void);
+        virtual WebBrowser* createWebBrowser(void);
+        virtual AudioManager* createAudioManager(void);
+        virtual ParticleSystemManager* createParticleSystemManager(void);
+
+private:
+        void handleEvent(const sf::Event& event);
 };
 
 GameEngine* CreateSfmlGameEngine();

--- a/Generals/Code/GameEngineDevice/Include/SfmlDevice/Common/SfmlLocalFileSystem.h
+++ b/Generals/Code/GameEngineDevice/Include/SfmlDevice/Common/SfmlLocalFileSystem.h
@@ -1,0 +1,67 @@
+/*
+**      Command & Conquer Generals(tm)
+**      Copyright 2025 Electronic Arts Inc.
+**
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
+**
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
+**
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  (c) 2001-2003 Electronic Arts Inc.                                        //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+// FILE: SfmlLocalFileSystem.h /////////////////////////////////////////////////
+// Author: OpenAI Assistant, 2025
+// Description:
+//   Platform-neutral local file system implementation used by the SFML
+//   bootstrap.
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#ifndef __SFMLLOCALFILESYSTEM_H
+#define __SFMLLOCALFILESYSTEM_H
+
+#include "Common/LocalFileSystem.h"
+
+class SfmlLocalFileSystem : public LocalFileSystem
+{
+public:
+        SfmlLocalFileSystem();
+        virtual ~SfmlLocalFileSystem();
+
+        virtual void init();
+        virtual void reset();
+        virtual void update();
+
+        virtual File* openFile(const Char* filename, Int access = 0);
+        virtual Bool doesFileExist(const Char* filename) const;
+        virtual void getFileListInDirectory(const AsciiString& currentDirectory,
+                                            const AsciiString& originalDirectory,
+                                            const AsciiString& searchName,
+                                            FilenameList& filenameList,
+                                            Bool searchSubdirectories) const;
+        virtual Bool getFileInfo(const AsciiString& filename, FileInfo* fileInfo) const;
+        virtual Bool createDirectory(AsciiString directory);
+
+private:
+        void enumerateDirectory(const AsciiString& currentDirectory,
+                                const AsciiString& originalDirectory,
+                                const AsciiString& searchName,
+                                FilenameList& filenameList,
+                                Bool searchSubdirectories) const;
+};
+
+#endif // __SFMLLOCALFILESYSTEM_H

--- a/Generals/Code/GameEngineDevice/Source/SfmlDevice/Common/SfmlBIGFile.cpp
+++ b/Generals/Code/GameEngineDevice/Source/SfmlDevice/Common/SfmlBIGFile.cpp
@@ -1,0 +1,127 @@
+/*
+**      Command & Conquer Generals(tm)
+**      Copyright 2025 Electronic Arts Inc.
+**
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
+**
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
+**
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  (c) 2001-2003 Electronic Arts Inc.                                        //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+// FILE: SfmlBIGFile.cpp ///////////////////////////////////////////////////////
+// Author: OpenAI Assistant, 2025
+// Description:
+//   Implementation of BIG archive file access helpers for the SFML device layer.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "SfmlDevice/Common/SfmlBIGFile.h"
+
+#include "Common/ArchiveFile.h"
+#include "Common/File.h"
+#include "Common/GameMemory.h"
+#include "Common/LocalFileSystem.h"
+#include "Common/RAMFile.h"
+#include "Common/StreamingArchiveFile.h"
+
+SfmlBIGFile::SfmlBIGFile() = default;
+SfmlBIGFile::~SfmlBIGFile() = default;
+
+File* SfmlBIGFile::openFile(const Char* filename, Int access)
+{
+        const ArchivedFileInfo* fileInfo = getArchivedFileInfo(AsciiString(filename));
+        if (fileInfo == NULL)
+        {
+                return NULL;
+        }
+
+        RAMFile* ramFile = NULL;
+        if (BitTest(access, File::STREAMING))
+        {
+                ramFile = newInstance(StreamingArchiveFile);
+        }
+        else
+        {
+                ramFile = newInstance(RAMFile);
+        }
+
+        if (ramFile == NULL)
+        {
+                return NULL;
+        }
+
+        ramFile->deleteOnClose();
+        if (ramFile->openFromArchive(m_file, fileInfo->m_filename, fileInfo->m_offset, fileInfo->m_size) == FALSE)
+        {
+                ramFile->close();
+                ramFile = NULL;
+                return NULL;
+        }
+
+        if ((access & File::WRITE) == 0)
+        {
+                return ramFile;
+        }
+
+        File* localFile = TheLocalFileSystem->openFile(filename, access);
+        if (localFile != NULL)
+        {
+                ramFile->copyDataToFile(localFile);
+        }
+
+        ramFile->close();
+        ramFile = NULL;
+
+        return localFile;
+}
+
+void SfmlBIGFile::closeAllFiles(void)
+{
+}
+
+AsciiString SfmlBIGFile::getName(void)
+{
+        return m_name;
+}
+
+AsciiString SfmlBIGFile::getPath(void)
+{
+        return m_path;
+}
+
+void SfmlBIGFile::setSearchPriority(Int new_priority)
+{
+        (void)new_priority;
+}
+
+void SfmlBIGFile::close(void)
+{
+}
+
+Bool SfmlBIGFile::getFileInfo(const AsciiString& filename, FileInfo* fileInfo) const
+{
+        const ArchivedFileInfo* tempFileInfo = getArchivedFileInfo(filename);
+        if (tempFileInfo == NULL)
+        {
+                return FALSE;
+        }
+
+        TheLocalFileSystem->getFileInfo(AsciiString(m_file->getName()), fileInfo);
+        fileInfo->sizeHigh = 0;
+        fileInfo->sizeLow = tempFileInfo->m_size;
+
+        return TRUE;
+}

--- a/Generals/Code/GameEngineDevice/Source/SfmlDevice/Common/SfmlBIGFileSystem.cpp
+++ b/Generals/Code/GameEngineDevice/Source/SfmlDevice/Common/SfmlBIGFileSystem.cpp
@@ -1,0 +1,206 @@
+/*
+**      Command & Conquer Generals(tm)
+**      Copyright 2025 Electronic Arts Inc.
+**
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
+**
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
+**
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  (c) 2001-2003 Electronic Arts Inc.                                        //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+// FILE: SfmlBIGFileSystem.cpp /////////////////////////////////////////////////
+// Author: OpenAI Assistant, 2025
+// Description:
+//   Implementation of the platform-neutral BIG archive file system for the
+//   SFML device layer.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "SfmlDevice/Common/SfmlBIGFileSystem.h"
+
+#include "Common/ArchiveFile.h"
+#include "Common/ArchiveFileSystem.h"
+#include "Common/AudioAffect.h"
+#include "Common/Debug.h"
+#include "Common/File.h"
+#include "Common/GameAudio.h"
+#include "Common/GameMemory.h"
+#include "Common/LocalFileSystem.h"
+#include "SfmlDevice/Common/SfmlBIGFile.h"
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+
+namespace
+{
+
+UnsignedInt readBigEndianUInt32(File* file)
+{
+        std::array<unsigned char, 4> buffer{};
+        if (file->read(buffer.data(), static_cast<Int>(buffer.size())) != static_cast<Int>(buffer.size()))
+        {
+                return 0;
+        }
+
+        return (static_cast<UnsignedInt>(buffer[0]) << 24) |
+               (static_cast<UnsignedInt>(buffer[1]) << 16) |
+               (static_cast<UnsignedInt>(buffer[2]) << 8) |
+               static_cast<UnsignedInt>(buffer[3]);
+}
+
+} // anonymous namespace
+
+SfmlBIGFileSystem::SfmlBIGFileSystem() = default;
+SfmlBIGFileSystem::~SfmlBIGFileSystem() = default;
+
+void SfmlBIGFileSystem::init(void)
+{
+        DEBUG_ASSERTCRASH(TheLocalFileSystem != NULL, ("TheLocalFileSystem must be initialized before TheArchiveFileSystem."));
+        if (TheLocalFileSystem == NULL)
+        {
+                return;
+        }
+
+        loadBigFilesFromDirectory("", "*.big");
+}
+
+void SfmlBIGFileSystem::reset(void)
+{
+}
+
+void SfmlBIGFileSystem::update(void)
+{
+}
+
+void SfmlBIGFileSystem::postProcessLoad(void)
+{
+}
+
+ArchiveFile* SfmlBIGFileSystem::openArchiveFile(const Char* filename)
+{
+        File* fp = TheLocalFileSystem->openFile(filename, File::READ | File::BINARY);
+        if (fp == NULL)
+        {
+                DEBUG_CRASH(("Could not open archive file %s for parsing", filename));
+                return NULL;
+        }
+
+        AsciiString archiveFileName(filename);
+        archiveFileName.toLower();
+
+        const char bigIdentifier[] = "BIGF";
+        std::array<char, 1024> buffer{};
+        fp->read(buffer.data(), 4);
+        buffer[4] = 0;
+
+        if (std::strncmp(buffer.data(), bigIdentifier, 4) != 0)
+        {
+                DEBUG_CRASH(("Error reading BIG file identifier in file %s", filename));
+                fp->close();
+                return NULL;
+        }
+
+        const Int archiveFileSize = static_cast<Int>(readBigEndianUInt32(fp));
+        (void)archiveFileSize;
+
+        const Int numLittleFiles = static_cast<Int>(readBigEndianUInt32(fp));
+
+        fp->seek(0x10, File::START);
+
+        ArchivedFileInfo* fileInfo = NEW ArchivedFileInfo;
+        ArchiveFile* archiveFile = NEW SfmlBIGFile;
+
+        for (Int i = 0; i < numLittleFiles; ++i)
+        {
+                const Int fileOffset = static_cast<Int>(readBigEndianUInt32(fp));
+                const Int fileSize = static_cast<Int>(readBigEndianUInt32(fp));
+
+                fileInfo->m_archiveFilename = archiveFileName;
+                fileInfo->m_offset = fileOffset;
+                fileInfo->m_size = fileSize;
+
+                Int pathIndex = -1;
+                do
+                {
+                        ++pathIndex;
+                        fp->read(buffer.data() + pathIndex, 1);
+                } while (buffer[pathIndex] != 0 && pathIndex < static_cast<Int>(buffer.size()) - 1);
+
+                Int filenameIndex = pathIndex;
+                while (filenameIndex >= 0 && buffer[filenameIndex] != '\\' && buffer[filenameIndex] != '/')
+                {
+                        --filenameIndex;
+                }
+
+                fileInfo->m_filename = (char*)(buffer.data() + filenameIndex + 1);
+                fileInfo->m_filename.toLower();
+                buffer[filenameIndex + 1] = 0;
+
+                AsciiString path(buffer.data());
+                archiveFile->addFile(path, fileInfo);
+        }
+
+        archiveFile->attachFile(fp);
+        delete fileInfo;
+
+        return archiveFile;
+}
+
+void SfmlBIGFileSystem::closeArchiveFile(const Char* filename)
+{
+        ArchiveFileMap::iterator it = m_archiveFileMap.find(AsciiString(filename));
+        if (it == m_archiveFileMap.end())
+        {
+                return;
+        }
+
+        if (AsciiString(filename).compareNoCase(MUSIC_BIG) == 0)
+        {
+                TheAudio->stopAudio(AudioAffect_Music);
+        }
+
+        delete it->second;
+        m_archiveFileMap.erase(it);
+}
+
+void SfmlBIGFileSystem::closeAllArchiveFiles(void)
+{
+}
+
+void SfmlBIGFileSystem::closeAllFiles(void)
+{
+}
+
+Bool SfmlBIGFileSystem::loadBigFilesFromDirectory(AsciiString dir, AsciiString fileMask, Bool overwrite)
+{
+        FilenameList filenameList;
+        TheLocalFileSystem->getFileListInDirectory(dir, AsciiString(""), fileMask, filenameList, TRUE);
+
+        Bool actuallyAdded = FALSE;
+        for (FilenameListIter it = filenameList.begin(); it != filenameList.end(); ++it)
+        {
+                ArchiveFile* archiveFile = openArchiveFile((*it).str());
+                if (archiveFile != NULL)
+                {
+                        loadIntoDirectoryTree(archiveFile, *it, overwrite);
+                        m_archiveFileMap[*it] = archiveFile;
+                        actuallyAdded = TRUE;
+                }
+        }
+
+        return actuallyAdded;
+}

--- a/Generals/Code/GameEngineDevice/Source/SfmlDevice/Common/SfmlGameEngine.cpp
+++ b/Generals/Code/GameEngineDevice/Source/SfmlDevice/Common/SfmlGameEngine.cpp
@@ -17,70 +17,292 @@
 */
 
 ////////////////////////////////////////////////////////////////////////////////
-//                                                                                                                             /
-/
-//  (c) 2001-2003 Electronic Arts Inc.                                                                                         /
-/
-//                                                                                                                             /
-/
+//                                                                            //
+//  (c) 2001-2003 Electronic Arts Inc.                                        //
+//                                                                            //
 ////////////////////////////////////////////////////////////////////////////////
 
-// FILE: SfmlGameEngine.cpp ///////////////////////////////////////////////////////////////////////
+// FILE: SfmlGameEngine.cpp ////////////////////////////////////////////////////
 // Author: OpenAI Assistant, 2025
 // Description:
 //   Implementation of the SFML-aware game engine device layer.
-///////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
 
 #include "SfmlDevice/Common/SfmlGameEngine.h"
 
+#include "Common/Debug.h"
+#include "Common/GameAudio.h"
 #include "Common/GameEngine.h"
+#include "Common/GlobalData.h"
+#include "Common/INIException.h"
+#include "Common/Recorder.h"
+#include "GameClient/Keyboard.h"
 #include "GameLogic/GameLogic.h"
 #include "GameNetwork/LANAPICallbacks.h"
+#include "GameNetwork/NetworkInterface.h"
+#include "SFML/Graphics/RenderWindow.hpp"
+#include "SFML/Window/Event.hpp"
+#include "SFMLPlatform/SfmlAudioManager.h"
+#include "SFMLPlatform/SfmlMouseBridge.h"
+#include "SFMLPlatform/WindowSystem.h"
+#include "SfmlDevice/Common/SfmlBIGFileSystem.h"
+#include "SfmlDevice/Common/SfmlLocalFileSystem.h"
+#include "W3DDevice/Common/W3DFunctionLexicon.h"
+#include "W3DDevice/Common/W3DModuleFactory.h"
+#include "W3DDevice/Common/W3DRadar.h"
+#include "W3DDevice/Common/W3DThingFactory.h"
+#include "W3DDevice/GameClient/W3DGameClient.h"
+#include "W3DDevice/GameClient/W3DParticleSys.h"
+#include "W3DDevice/GameLogic/W3DGameLogic.h"
+#include "W3DDevice/GameClient/RenderBackend.h"
+#if defined(_WIN32)
+#include "W3DDevice/GameClient/W3DWebBrowser.h"
+#include <atlbase.h>
+#endif
 
 #include <chrono>
 #include <thread>
 
-SfmlGameEngine::SfmlGameEngine() = default;
+namespace
+{
 
+using Clock = std::chrono::steady_clock;
+
+} // anonymous namespace
+
+SfmlGameEngine::SfmlGameEngine() = default;
 SfmlGameEngine::~SfmlGameEngine() = default;
 
-void SfmlGameEngine::update( void )
+void SfmlGameEngine::execute(void)
 {
-        GameEngine::update();
-
-        if( !isActive() )
+        sfml_platform::WindowSystem* windowSystem = sfml_platform::GetActiveWindowSystem();
+        if (windowSystem == NULL)
         {
-                while( !isActive() )
-                {
-                        std::this_thread::sleep_for( std::chrono::milliseconds( 5 ) );
-                        serviceWindowsOS();
-
-                        if( TheLAN != NULL )
-                        {
-                                TheLAN->setIsActive( isActive() );
-                                TheLAN->update();
-                        }
-
-                        if( getQuitting() || TheGameLogic->isInInternetGame() || TheGameLogic->isInLanGame() )
-                        {
-                                break;
-                        }
-                }
-        }
-
-        serviceWindowsOS();
-}
-
-void SfmlGameEngine::serviceWindowsOS( void )
-{
-        WindowsMessagePumpOverride pump = GetWindowsMessagePumpOverride();
-        if( pump != NULL )
-        {
-                pump();
+                GameEngine::execute();
                 return;
         }
 
-        Win32GameEngine::serviceWindowsOS();
+        const auto startTime = Clock::now();
+
+        windowSystem->run(
+                [this, startTime](sf::RenderWindow& window, float /*delta*/)
+                {
+                        if (getQuitting())
+                        {
+                                window.close();
+                                return;
+                        }
+
+#if defined(_DEBUG) || defined(_INTERNAL)
+                        if (TheGlobalData->m_benchmarkTimer > 0)
+                        {
+                                const auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(Clock::now() - startTime).count();
+                                if (TheGlobalData->m_benchmarkTimer < elapsed)
+                                {
+                                        if (TheGameLogic->isInGame())
+                                        {
+                                                if (TheRecorder->getMode() == RECORDERMODETYPE_RECORD)
+                                                {
+                                                        TheRecorder->stopRecording();
+                                                }
+                                                TheGameLogic->clearGameData();
+                                        }
+                                        setQuitting(TRUE);
+                                }
+                        }
+#endif
+
+                        try
+                        {
+                                GameEngine::update();
+                        }
+                        catch (INIException e)
+                        {
+                                if (e.mFailureMessage)
+                                {
+                                        RELEASE_CRASH((e.mFailureMessage));
+                                }
+                                else
+                                {
+                                        RELEASE_CRASH(("Uncaught Exception in GameEngine::update"));
+                                }
+                        }
+                        catch (...)
+                        {
+                                try
+                                {
+                                        if (TheRecorder && TheRecorder->getMode() == RECORDERMODETYPE_RECORD && TheRecorder->isMultiplayer())
+                                        {
+                                                TheRecorder->cleanUpReplayFile();
+                                        }
+                                }
+                                catch (...)
+                                {
+                                }
+                                RELEASE_CRASH(("Uncaught Exception in GameEngine::update"));
+                        }
+
+                        if (getQuitting())
+                        {
+                                window.close();
+                        }
+
+                        if (auto* mouse = sfml_platform::GetActiveMouseBridge())
+                        {
+                                mouse->refreshCursor();
+                        }
+                },
+                nullptr,
+                [this](const sf::Event& event)
+                {
+                        handleEvent(event);
+                });
+}
+
+void SfmlGameEngine::update(void)
+{
+        GameEngine::update();
+
+        if (!isActive())
+        {
+                std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+                if (TheLAN != NULL)
+                {
+                        TheLAN->setIsActive(isActive());
+                        TheLAN->update();
+                }
+        }
+}
+
+GameLogic* SfmlGameEngine::createGameLogic(void)
+{
+        return NEW W3DGameLogic;
+}
+
+GameClient* SfmlGameEngine::createGameClient(void)
+{
+        return NEW W3DGameClient;
+}
+
+ModuleFactory* SfmlGameEngine::createModuleFactory(void)
+{
+        return NEW W3DModuleFactory;
+}
+
+ThingFactory* SfmlGameEngine::createThingFactory(void)
+{
+        return NEW W3DThingFactory;
+}
+
+FunctionLexicon* SfmlGameEngine::createFunctionLexicon(void)
+{
+        return NEW W3DFunctionLexicon;
+}
+
+LocalFileSystem* SfmlGameEngine::createLocalFileSystem(void)
+{
+        return NEW SfmlLocalFileSystem;
+}
+
+ArchiveFileSystem* SfmlGameEngine::createArchiveFileSystem(void)
+{
+        return NEW SfmlBIGFileSystem;
+}
+
+NetworkInterface* SfmlGameEngine::createNetwork(void)
+{
+        return NetworkInterface::createNetwork();
+}
+
+Radar* SfmlGameEngine::createRadar(void)
+{
+        return NEW W3DRadar;
+}
+
+WebBrowser* SfmlGameEngine::createWebBrowser(void)
+{
+#if defined(_WIN32)
+        return NEW CComObject<W3DWebBrowser>;
+#else
+        return NULL;
+#endif
+}
+
+AudioManager* SfmlGameEngine::createAudioManager(void)
+{
+        AudioManagerFactoryFunction factory = GetAudioManagerFactoryOverride();
+        if (factory != NULL)
+        {
+                return factory();
+        }
+        return NEW SfmlAudioManager;
+}
+
+ParticleSystemManager* SfmlGameEngine::createParticleSystemManager(void)
+{
+        return NEW W3DParticleSystemManager;
+}
+
+void SfmlGameEngine::handleEvent(const sf::Event& event)
+{
+        switch (event.type)
+        {
+                case sf::Event::Closed:
+                        checkAbnormalQuitting();
+                        reset();
+                        setQuitting(TRUE);
+                        break;
+
+                case sf::Event::LostFocus:
+                        if (TheKeyboard)
+                        {
+                                TheKeyboard->resetKeys();
+                        }
+                        if (auto* mouse = sfml_platform::GetActiveMouseBridge())
+                        {
+                                mouse->lostFocus(TRUE);
+                        }
+                        setIsActive(FALSE);
+#if defined(_WIN32)
+                        GetRenderBackend().HandleFocusChange(false);
+#endif
+                        if (TheAudio)
+                        {
+                                TheAudio->loseFocus();
+                        }
+                        break;
+
+                case sf::Event::GainedFocus:
+                        if (TheKeyboard)
+                        {
+                                TheKeyboard->resetKeys();
+                        }
+                        if (auto* mouse = sfml_platform::GetActiveMouseBridge())
+                        {
+                                mouse->lostFocus(FALSE);
+                                mouse->refreshCursor();
+                        }
+                        setIsActive(TRUE);
+#if defined(_WIN32)
+                        GetRenderBackend().HandleFocusChange(true);
+#endif
+                        if (TheAudio)
+                        {
+                                TheAudio->regainFocus();
+                        }
+                        break;
+
+                case sf::Event::MouseEntered:
+                        if (auto* mouse = sfml_platform::GetActiveMouseBridge())
+                        {
+                                mouse->refreshCursor();
+                        }
+                        break;
+
+                default:
+                        break;
+        }
 }
 
 GameEngine* CreateSfmlGameEngine()

--- a/Generals/Code/GameEngineDevice/Source/SfmlDevice/Common/SfmlLocalFileSystem.cpp
+++ b/Generals/Code/GameEngineDevice/Source/SfmlDevice/Common/SfmlLocalFileSystem.cpp
@@ -1,0 +1,296 @@
+/*
+**      Command & Conquer Generals(tm)
+**      Copyright 2025 Electronic Arts Inc.
+**
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
+**
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
+**
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+//  (c) 2001-2003 Electronic Arts Inc.                                        //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+// FILE: SfmlLocalFileSystem.cpp ///////////////////////////////////////////////
+// Author: OpenAI Assistant, 2025
+// Description:
+//   Implementation of a platform-neutral local file system used by the SFML
+//   bootstrap.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "SfmlDevice/Common/SfmlLocalFileSystem.h"
+
+#include "Common/AsciiString.h"
+#include "Common/GameMemory.h"
+#include "Common/LocalFile.h"
+
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#if defined(_WIN32)
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace
+{
+
+bool matchPattern(std::string_view pattern, std::string_view candidate)
+{
+        std::string lowerPattern(pattern);
+        std::string lowerCandidate(candidate);
+        std::transform(lowerPattern.begin(), lowerPattern.end(), lowerPattern.begin(), [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+        std::transform(lowerCandidate.begin(), lowerCandidate.end(), lowerCandidate.begin(), [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+
+        const char* p = lowerPattern.c_str();
+        const char* s = lowerCandidate.c_str();
+        const char* star = nullptr;
+        const char* match = nullptr;
+
+        while (*s != '\0')
+        {
+                if (*p == '?' || *p == *s)
+                {
+                        ++p;
+                        ++s;
+                }
+                else if (*p == '*')
+                {
+                        star = p++;
+                        match = s;
+                }
+                else if (star != nullptr)
+                {
+                        p = star + 1;
+                        s = ++match;
+                }
+                else
+                {
+                        return false;
+                }
+        }
+
+        while (*p == '*')
+        {
+                ++p;
+        }
+
+        return *p == '\0';
+}
+
+std::filesystem::path toPath(const AsciiString& path)
+{
+        std::string temp = path.str();
+        std::replace(temp.begin(), temp.end(), '\\', std::filesystem::path::preferred_separator);
+        return std::filesystem::path(temp);
+}
+
+} // anonymous namespace
+
+SfmlLocalFileSystem::SfmlLocalFileSystem() = default;
+SfmlLocalFileSystem::~SfmlLocalFileSystem() = default;
+
+void SfmlLocalFileSystem::init()
+{
+}
+
+void SfmlLocalFileSystem::reset()
+{
+}
+
+void SfmlLocalFileSystem::update()
+{
+}
+
+File* SfmlLocalFileSystem::openFile(const Char* filename, Int access)
+{
+        LocalFile* file = newInstance(LocalFile);
+
+        if (filename == NULL || *filename == '\0')
+        {
+                return NULL;
+        }
+
+        if ((access & File::WRITE) != 0)
+        {
+                std::filesystem::path targetPath = toPath(AsciiString(filename));
+                if (targetPath.has_parent_path())
+                {
+                        std::error_code ec;
+                        std::filesystem::create_directories(targetPath.parent_path(), ec);
+                }
+        }
+
+        if (file->open(filename, access) == FALSE)
+        {
+                file->close();
+                file->deleteInstance();
+                return NULL;
+        }
+
+        file->deleteOnClose();
+        return file;
+}
+
+Bool SfmlLocalFileSystem::doesFileExist(const Char* filename) const
+{
+        if (filename == NULL)
+        {
+                return FALSE;
+        }
+
+#if defined(_WIN32)
+        return (_access(filename, 0) == 0) ? TRUE : FALSE;
+#else
+        return (access(filename, F_OK) == 0) ? TRUE : FALSE;
+#endif
+}
+
+void SfmlLocalFileSystem::getFileListInDirectory(const AsciiString& currentDirectory,
+                                                 const AsciiString& originalDirectory,
+                                                 const AsciiString& searchName,
+                                                 FilenameList& filenameList,
+                                                 Bool searchSubdirectories) const
+{
+        enumerateDirectory(currentDirectory, originalDirectory, searchName, filenameList, searchSubdirectories);
+}
+
+void SfmlLocalFileSystem::enumerateDirectory(const AsciiString& currentDirectory,
+                                             const AsciiString& originalDirectory,
+                                             const AsciiString& searchName,
+                                             FilenameList& filenameList,
+                                             Bool searchSubdirectories) const
+{
+        namespace fs = std::filesystem;
+
+        fs::path basePath = toPath(originalDirectory);
+        fs::path relativePath = toPath(currentDirectory);
+        fs::path searchPath = basePath / relativePath;
+
+        std::error_code ec;
+        if (!fs::exists(searchPath, ec) || !fs::is_directory(searchPath, ec))
+        {
+                return;
+        }
+
+        const std::string pattern = searchName.str();
+
+        for (fs::directory_iterator iter(searchPath, ec); !ec && iter != fs::directory_iterator(); ++iter)
+        {
+                if (!iter->is_regular_file(ec))
+                {
+                        continue;
+                }
+
+                const std::string filename = iter->path().filename().string();
+                if (!matchPattern(pattern, filename))
+                {
+                        continue;
+                }
+
+                AsciiString fullPath = originalDirectory;
+                fullPath.concat(currentDirectory);
+                fullPath.concat(filename.c_str());
+
+                if (filenameList.find(fullPath) == filenameList.end())
+                {
+                        filenameList.insert(fullPath);
+                }
+        }
+
+        if (!searchSubdirectories)
+        {
+                return;
+        }
+
+        ec.clear();
+        for (fs::directory_iterator iter(searchPath, ec); !ec && iter != fs::directory_iterator(); ++iter)
+        {
+                if (!iter->is_directory(ec))
+                {
+                        continue;
+                }
+
+                const std::string folder = iter->path().filename().string();
+                if (folder == "." || folder == "..")
+                {
+                        continue;
+                }
+
+                AsciiString nextDirectory = currentDirectory;
+                nextDirectory.concat(folder.c_str());
+                nextDirectory.concat("\\");
+
+                enumerateDirectory(nextDirectory, originalDirectory, searchName, filenameList, searchSubdirectories);
+        }
+}
+
+Bool SfmlLocalFileSystem::getFileInfo(const AsciiString& filename, FileInfo* fileInfo) const
+{
+        if (fileInfo == NULL)
+        {
+                return FALSE;
+        }
+
+        namespace fs = std::filesystem;
+        fs::path path = toPath(filename);
+
+        std::error_code ec;
+        if (!fs::exists(path, ec))
+        {
+                return FALSE;
+        }
+
+        const uintmax_t size = fs::file_size(path, ec);
+        if (ec)
+        {
+                return FALSE;
+        }
+
+        auto writeTime = fs::last_write_time(path, ec);
+        if (ec)
+        {
+                return FALSE;
+        }
+
+        const auto sysTime = std::chrono::time_point_cast<std::chrono::nanoseconds>(writeTime - fs::file_time_type::clock::now() + std::chrono::system_clock::now());
+        const auto timestamp = static_cast<unsigned long long>(sysTime.time_since_epoch().count());
+
+        fileInfo->sizeHigh = static_cast<Int>((static_cast<unsigned long long>(size) >> 32) & 0xFFFFFFFFULL);
+        fileInfo->sizeLow = static_cast<Int>(static_cast<unsigned long long>(size) & 0xFFFFFFFFULL);
+        fileInfo->timestampHigh = static_cast<Int>((timestamp >> 32) & 0xFFFFFFFFULL);
+        fileInfo->timestampLow = static_cast<Int>(timestamp & 0xFFFFFFFFULL);
+
+        return TRUE;
+}
+
+Bool SfmlLocalFileSystem::createDirectory(AsciiString directory)
+{
+        namespace fs = std::filesystem;
+        fs::path path = toPath(directory);
+
+        std::error_code ec;
+        if (fs::exists(path, ec))
+        {
+                                return TRUE;
+        }
+
+        return fs::create_directories(path, ec) ? TRUE : FALSE;
+}

--- a/Generals/Code/SFMLPlatform/WindowSystem.cpp
+++ b/Generals/Code/SFMLPlatform/WindowSystem.cpp
@@ -27,6 +27,8 @@ namespace sfml_platform {
 
 namespace {
 
+WindowSystem* g_activeWindowSystem = nullptr;
+
 #if defined(SFML_SYSTEM_LINUX)
 Display* acquireX11Display() {
     static Display* display = nullptr;
@@ -197,6 +199,14 @@ NativeWindowHandle WindowSystem::nativeHandle() const {
 #endif
 
     return handle;
+}
+
+void SetActiveWindowSystem(WindowSystem* system) {
+    g_activeWindowSystem = system;
+}
+
+WindowSystem* GetActiveWindowSystem() {
+    return g_activeWindowSystem;
 }
 
 } // namespace sfml_platform

--- a/Generals/Code/SFMLPlatform/WindowSystem.h
+++ b/Generals/Code/SFMLPlatform/WindowSystem.h
@@ -42,4 +42,7 @@ private:
     bool m_running = false;
 };
 
+void SetActiveWindowSystem(WindowSystem* system);
+WindowSystem* GetActiveWindowSystem();
+
 } // namespace sfml_platform


### PR DESCRIPTION
## Summary
- restructure the SFML game engine to drive execution through WindowSystem::run, handle SFML events directly, and supply the necessary device factories
- introduce platform-neutral local and BIG archive file system implementations for the SFML device layer
- expose helpers for tracking the active WindowSystem and update the SFML bootstrap to use them instead of Win32 message pump overrides

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cdb28fc364833191f75fd0b712fe9c