### PR TITLE
Refactor ThreadClass to use std::thread

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WWDebug/wwmemlog.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWDebug/wwmemlog.cpp
@@ -42,7 +42,7 @@
 #include "wwmemlog.h"
 #include "wwdebug.h"
 #include "vector.h"
-#include <windows.h>
+#include "thread.h"
 
 #if (STEVES_NEW_CATCHER || PARAM_EDITING_ON)
 	#define DISABLE_MEMLOG	1
@@ -276,7 +276,7 @@ ActiveCategoryStackClass::operator = (const ActiveCategoryStackClass & that)
 ***************************************************************************************************/
 ActiveCategoryStackClass & ActiveCategoryClass::Get_Active_Stack(void)
 {
-	int current_thread = ::GetCurrentThreadId();
+        int current_thread = ThreadClass::_Get_Current_Thread_ID();
 
 	/*
 	** If we already have an allocated category stack for the current thread,

--- a/Generals/Code/Libraries/Source/WWVegas/WWDebug/wwprofile.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWDebug/wwprofile.cpp
@@ -53,7 +53,7 @@
 #include "always.h"
 #include "wwprofile.h"
 #include "wwdebug.h"
-#include <windows.h>
+#include "thread.h"
 
 
 
@@ -318,7 +318,7 @@ static unsigned int				ThreadID = static_cast<unsigned int>(-1);
  *=============================================================================================*/
 void	WWProfileManager::Start_Profile( const char * name )
 {
-	if (::GetCurrentThreadId() != ThreadID) {
+        if (ThreadClass::_Get_Current_Thread_ID() != ThreadID) {
 		return;
 	}
 
@@ -345,7 +345,7 @@ void	WWProfileManager::Start_Profile( const char * name )
  *=============================================================================================*/
 void	WWProfileManager::Stop_Profile( void )
 {
-	if (::GetCurrentThreadId() != ThreadID) {
+        if (ThreadClass::_Get_Current_Thread_ID() != ThreadID) {
 		return;
 	}
 
@@ -374,7 +374,7 @@ void	WWProfileManager::Stop_Profile( void )
  *=============================================================================================*/
 void	WWProfileManager::Reset( void )
 { 
-	ThreadID = ::GetCurrentThreadId();
+        ThreadID = ThreadClass::_Get_Current_Thread_ID();
 
 	Root.Reset(); 
 	FrameCounter = 0;

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/thread.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/thread.h
@@ -1,19 +1,19 @@
 /*
-**	Command & Conquer Generals(tm)
-**	Copyright 2025 Electronic Arts Inc.
+**      Command & Conquer Generals(tm)
+**      Copyright 2025 Electronic Arts Inc.
 **
-**	This program is free software: you can redistribute it and/or modify
-**	it under the terms of the GNU General Public License as published by
-**	the Free Software Foundation, either version 3 of the License, or
-**	(at your option) any later version.
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
 **
-**	This program is distributed in the hope that it will be useful,
-**	but WITHOUT ANY WARRANTY; without even the implied warranty of
-**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-**	GNU General Public License for more details.
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
 **
-**	You should have received a copy of the GNU General Public License
-**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #ifndef THREAD_H
@@ -28,6 +28,11 @@
 
 #include "always.h"
 
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
 
 // ****************************************************************************
 //
@@ -40,7 +45,7 @@
 // will clear the flag and expect you to exit from the thread. If you are
 // not exiting in certain time (defined as a parameter to Stop()) it will
 // force-kill the thread to prevent the program from halting.
-// 
+//
 // ****************************************************************************
 
 class ThreadClass
@@ -75,11 +80,14 @@ protected:
 	// User defined thread function. The thread function should check for "running" flag every now and then
 	// and exit the thread if running is false.
 	virtual void Thread_Function() = 0;
-	volatile bool running;
+	std::atomic<bool> running;
 
 private:
-	static void __cdecl Internal_Thread_Function(void*);
-	volatile unsigned long handle;
+	void Internal_Thread_Function();
+	std::thread thread_handle;
+	std::mutex thread_mutex;
+	std::condition_variable thread_cv;
+	bool thread_active;
 	int thread_priority;
 };
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWDebug/wwmemlog.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWDebug/wwmemlog.cpp
@@ -43,7 +43,7 @@
 #include "wwdebug.h"
 #include "vector.h"
 #include "fastallocator.h"
-#include <windows.h>
+#include "thread.h"
 
 #define USE_FAST_ALLOCATOR
 
@@ -392,7 +392,7 @@ ActiveCategoryStackClass::operator = (const ActiveCategoryStackClass & that)
 ***************************************************************************************************/
 ActiveCategoryStackClass & ActiveCategoryClass::Get_Active_Stack(void)
 {
-	int current_thread = ::GetCurrentThreadId();
+        int current_thread = ThreadClass::_Get_Current_Thread_ID();
 
 	/*
 	** If we already have an allocated category stack for the current thread,

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWDebug/wwprofile.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWDebug/wwprofile.cpp
@@ -53,7 +53,7 @@
 #include "wwprofile.h"
 #include "fastallocator.h"
 #include "wwdebug.h"
-#include <windows.h>
+#include "thread.h"
 //#include "systimer.h"
 #include "systimer.h"
 #include "rawfile.h"
@@ -389,7 +389,7 @@ static unsigned int				ThreadID = static_cast<unsigned int>(-1);
  *=============================================================================================*/
 void	WWProfileManager::Start_Profile( const char * name )
 {
-	if (::GetCurrentThreadId() != ThreadID) {
+    if (ThreadClass::_Get_Current_Thread_ID() != ThreadID) {
 		return;
 	}
 
@@ -403,7 +403,7 @@ void	WWProfileManager::Start_Profile( const char * name )
 
 void	WWProfileManager::Start_Root_Profile( const char * name )
 {
-	if (::GetCurrentThreadId() != ThreadID) {
+    if (ThreadClass::_Get_Current_Thread_ID() != ThreadID) {
 		return;
 	}
 
@@ -429,7 +429,7 @@ void	WWProfileManager::Start_Root_Profile( const char * name )
  *=============================================================================================*/
 void	WWProfileManager::Stop_Profile( void )
 {
-	if (::GetCurrentThreadId() != ThreadID) {
+    if (ThreadClass::_Get_Current_Thread_ID() != ThreadID) {
 		return;
 	}
 
@@ -442,7 +442,7 @@ void	WWProfileManager::Stop_Profile( void )
 
 void	WWProfileManager::Stop_Root_Profile( void )
 {
-	if (::GetCurrentThreadId() != ThreadID) {
+    if (ThreadClass::_Get_Current_Thread_ID() != ThreadID) {
 		return;
 	}
 
@@ -471,7 +471,7 @@ void	WWProfileManager::Stop_Root_Profile( void )
  *=============================================================================================*/
 void	WWProfileManager::Reset( void )
 {
-	ThreadID = ::GetCurrentThreadId();
+    ThreadID = ThreadClass::_Get_Current_Thread_ID();
 
 	Root.Reset();
 	FrameCounter = 0;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/Except.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/Except.cpp
@@ -561,7 +561,7 @@ void Dump_Exception_Info(EXCEPTION_POINTERS *e_info)
 	for (int thread = 0 ; thread < ThreadList.Count() ; thread++) {
 		sprintf(scrap, "  ID: %08X - %s", ThreadList[thread]->ThreadID, ThreadList[thread]->ThreadName);
 		Add_Txt(scrap);
-		if (GetCurrentThreadId() == ThreadList[thread]->ThreadID) {
+		if (ThreadClass::_Get_Current_Thread_ID() == ThreadList[thread]->ThreadID) {
 			Add_Txt("   ***CURRENT THREAD***");
 		}
 		Add_Txt("\r\n");
@@ -855,7 +855,7 @@ int Exception_Handler(int exception_code, EXCEPTION_POINTERS *e_info)
 		TryingToExit = true;
 
 		unsigned long id = Get_Main_Thread_ID();
-		if (id != GetCurrentThreadId()) {
+		if (id != ThreadClass::_Get_Current_Thread_ID()) {
 			DebugString("Exiting due to exception in sub thread\n");
 			ExitProcess(EXIT_SUCCESS);
 		}

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/thread.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/thread.h
@@ -1,19 +1,19 @@
 /*
-**	Command & Conquer Generals Zero Hour(tm)
-**	Copyright 2025 Electronic Arts Inc.
+**      Command & Conquer Generals Zero Hour(tm)
+**      Copyright 2025 Electronic Arts Inc.
 **
-**	This program is free software: you can redistribute it and/or modify
-**	it under the terms of the GNU General Public License as published by
-**	the Free Software Foundation, either version 3 of the License, or
-**	(at your option) any later version.
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
 **
-**	This program is distributed in the hope that it will be useful,
-**	but WITHOUT ANY WARRANTY; without even the implied warranty of
-**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-**	GNU General Public License for more details.
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
 **
-**	You should have received a copy of the GNU General Public License
-**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #ifndef THREAD_H
@@ -28,6 +28,11 @@
 
 #include "always.h"
 #include "vector.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
 
 struct _EXCEPTION_POINTERS;
 
@@ -49,58 +54,61 @@ struct _EXCEPTION_POINTERS;
 class ThreadClass
 {
 public:
-	typedef int (*ExceptionHandlerType)(int exception_code, struct _EXCEPTION_POINTERS *e_info);
+        typedef int (*ExceptionHandlerType)(int exception_code, struct _EXCEPTION_POINTERS *e_info);
 
-	ThreadClass(const char *name = NULL, ExceptionHandlerType exception_handler = NULL);
-	virtual ~ThreadClass();
+        ThreadClass(const char *name = NULL, ExceptionHandlerType exception_handler = NULL);
+        virtual ~ThreadClass();
 
-	// Execute Thread_Function(). Note that only one instance can be executed at a time.
-	void Execute();
+        // Execute Thread_Function(). Note that only one instance can be executed at a time.
+        void Execute();
 
-	// Thread priority 0 is normal, positive numbers are higher and normal and negative are lower.
-	void Set_Priority(int priority);
+        // Thread priority 0 is normal, positive numbers are higher and normal and negative are lower.
+        void Set_Priority(int priority);
 
-	// Stop thread execution. Kill after ms milliseconds if not responding.
-	void Stop(unsigned ms=3000);
+        // Stop thread execution. Kill after ms milliseconds if not responding.
+        void Stop(unsigned ms=3000);
 
-	// Put current thread sleep for ms milliseconds (can be called from any thread, ThreadClass or other)
-	static void Sleep_Ms(unsigned ms=0);
+        // Put current thread sleep for ms milliseconds (can be called from any thread, ThreadClass or other)
+        static void Sleep_Ms(unsigned ms=0);
 
-	// Put current thread in sleep and switch to next one (Useful for balansing the thread switches with game update)
-	static void Switch_Thread();
+        // Put current thread in sleep and switch to next one (Useful for balansing the thread switches with game update)
+        static void Switch_Thread();
 
-	// Return calling thread's unique thread id
-	static unsigned _Get_Current_Thread_ID();
+        // Return calling thread's unique thread id
+        static unsigned _Get_Current_Thread_ID();
 
-	// Returns true if the thread is running.
-	bool Is_Running();
+        // Returns true if the thread is running.
+        bool Is_Running();
 
-	// Gets the name of the thread.
-	const char *Get_Name(void) {return(ThreadName);};
+        // Gets the name of the thread.
+        const char *Get_Name(void) {return(ThreadName);};
 
-	// Get info about a registered thread by it's index.
-	static int Get_Thread_By_Index(int index, char *name_ptr = NULL);
+        // Get info about a registered thread by it's index.
+        static int Get_Thread_By_Index(int index, char *name_ptr = NULL);
 
 protected:
 
-	// User defined thread function. The thread function should check for "running" flag every now and then
-	// and exit the thread if running is false.
-	virtual void Thread_Function() = 0;
-	volatile bool running;
+        // User defined thread function. The thread function should check for "running" flag every now and then
+        // and exit the thread if running is false.
+        virtual void Thread_Function() = 0;
+        std::atomic<bool> running;
 
-	// Name of thread.
-	char ThreadName[64];
+        // Name of thread.
+        char ThreadName[64];
 
-	// ID of thread.
-	unsigned ThreadID;
+        // ID of thread.
+        unsigned ThreadID;
 
-	// Exception handler for this thread.
-	ExceptionHandlerType ExceptionHandler;
+        // Exception handler for this thread.
+        ExceptionHandlerType ExceptionHandler;
 
 private:
-	static void __cdecl Internal_Thread_Function(void*);
-	volatile unsigned long handle;
-	int thread_priority;
+        void Internal_Thread_Function();
+        std::thread thread_handle;
+        std::mutex thread_mutex;
+        std::condition_variable thread_cv;
+        bool thread_active;
+        int thread_priority;
 };
 
 #endif


### PR DESCRIPTION
## Summary
- replace the Win32-specific ThreadClass implementation with std::thread, std::atomic, and std::condition_variable in both Generals and Zero Hour code paths
- rework Stop, Sleep_Ms, and Switch_Thread to use standard library timing/yield facilities and remove forced TerminateThread shutdowns while tracking thread lifecycle state
- update wwprofile, wwmemlog, and exception handling to rely on the new ThreadClass helpers so that Windows headers are no longer required at those call sites

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ce4f7189408331867b3deec46f010f