### PR TITLE
Replace Win32 multimedia timers with chrono

### DIFF
--- a/Generals/Code/Libraries/Source/WWVegas/WWDownload/Download.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWDownload/Download.cpp
@@ -19,7 +19,7 @@
 // Download.cpp : Implementation of CDownload
 #include "DownloadDebug.h"
 #include "download.h"
-#include <mmsystem.h>
+#include "systimer.h"
 #include <assert.h>
 #include <direct.h>
 #include <stdlib.h>
@@ -337,7 +337,7 @@ HRESULT CDownload::PumpMessages()
 		if( m_TimeStarted == 0 )
 		{
 			// This is the first time through here - record the starting time.
-			m_TimeStarted = timeGetTime();
+			m_TimeStarted = SystemTime.Get_Milliseconds();
 		}
 
 		if( iResult == FTP_SUCCEEDED )
@@ -357,7 +357,7 @@ HRESULT CDownload::PumpMessages()
 		// Calculate time taken so far, and predict how long there is left.
 		// The prediction returned is the average of the last 8 predictions.
 
-		timetaken = ( timeGetTime() - m_TimeStarted ) / 1000;
+		timetaken = static_cast<int>((SystemTime.Get_Milliseconds() - m_TimeStarted) / 1000);
 
 		//////////if( m_BytesRead > 0 ) // NAK - RP said this is wrong
       if( ( m_BytesRead - m_StartPosition ) > 0 )

--- a/Generals/Code/Libraries/Source/WWVegas/WWDownload/Download.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWDownload/Download.h
@@ -24,6 +24,7 @@
 //#include "../resource.h"       // main symbols
 #include "WWDownload/ftp.h"
 #include "WWDownload/downloaddefs.h"
+#include <cstdint>
 
 /////////////////////////////////////////////////////////////////////////////
 // CDownload
@@ -83,7 +84,7 @@ private:
 
 	char m_RegKey[ 256 ];
 	int  m_Status;
-	int  m_TimeStarted;
+	std::uint64_t  m_TimeStarted;
 	int  m_StartPosition;
 	int  m_FileSize;
 	int  m_BytesRead;

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/stimer.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/stimer.cpp
@@ -36,26 +36,16 @@
 
 #include	"always.h"
 #include	"stimer.h"
+#include	"systimer.h"
 #include	"win.h"
-
-#ifdef _MSC_VER
-#pragma warning (push,3)
-#endif
-
-#include <mmsystem.h>
-
-#ifdef _MSC_VER
-#pragma warning (pop)
-#endif
-
 
 long SystemTimerClass::operator () (void) const
 {
-	return timeGetTime()/16;
+	return static_cast<long>(SystemTime.Get_Milliseconds() / 16);
 }
 
 
 SystemTimerClass::operator long (void) const
 {
-	return timeGetTime()/16;
+	return static_cast<long>(SystemTime.Get_Milliseconds() / 16);
 }

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/systimer.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/systimer.cpp
@@ -53,10 +53,8 @@ SysTimeClass SystemTime;
  * HISTORY:                                                                                    *
  *   01/04/2003 : Created by Mark Wilczynski (EAP)                                             *
  *=============================================================================================*/
-SysTimeClass::SysTimeClass(void)
+SysTimeClass::SysTimeClass(void) : StartTime(clock_type::now())
 {
-	//tell windows we need single ms precision.
-	timeBeginPeriod(1);
 }
 
 /***********************************************************************************************
@@ -73,11 +71,7 @@ SysTimeClass::SysTimeClass(void)
  * HISTORY:                                                                                    *
  *   01/04/2003 : Created by Mark Wilczynski (EAP)                                             *
  *=============================================================================================*/
-SysTimeClass::~SysTimeClass(void)
-{
-	//tell windows we need single ms precision.
-	timeEndPeriod(1);
-}
+SysTimeClass::~SysTimeClass(void) = default;
 
 /***********************************************************************************************
  * SysTimeClass::Reset -- Reset class to good state                                            *
@@ -95,8 +89,7 @@ SysTimeClass::~SysTimeClass(void)
  *=============================================================================================*/
 void SysTimeClass::Reset(void)
 {
-	StartTime = timeGetTime();
-	WrapAdd = 0 - StartTime;
+	StartTime = clock_type::now();
 }
 
 
@@ -121,10 +114,7 @@ bool SysTimeClass::Is_Getting_Late(void)
 	** Even though the timers are all unsigned so we have a max time of 0xffffffff the game casts it to int in various places
 	** so it's safer to assume a signed max value.
 	*/
-	if (Get() > 0x6fffffff) {
-		return(true);
-	}
-	return(false);
+	return(Get_Milliseconds() > 0x6fffffffULL);
 }
 
 

--- a/Generals/Code/Libraries/Source/WWVegas/Wwutil/miscutil.cpp
+++ b/Generals/Code/Libraries/Source/WWVegas/Wwutil/miscutil.cpp
@@ -31,7 +31,6 @@
 #include "rawfile.h"
 #include "wwdebug.h"
 #include "win.h"
-#include "mmsys.h"
 #include "ffactory.h"
 
 //

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWDownload/Download.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWDownload/Download.cpp
@@ -19,7 +19,7 @@
 // Download.cpp : Implementation of CDownload
 #include "DownloadDebug.h"
 #include "download.h"
-#include <mmsystem.h>
+#include "systimer.h"
 #include <assert.h>
 #include <direct.h>
 #include <stdlib.h>
@@ -337,7 +337,7 @@ HRESULT CDownload::PumpMessages()
 		if( m_TimeStarted == 0 )
 		{
 			// This is the first time through here - record the starting time.
-			m_TimeStarted = timeGetTime();
+			m_TimeStarted = SystemTime.Get_Milliseconds();
 		}
 
 		if( iResult == FTP_SUCCEEDED )
@@ -357,7 +357,7 @@ HRESULT CDownload::PumpMessages()
 		// Calculate time taken so far, and predict how long there is left.
 		// The prediction returned is the average of the last 8 predictions.
 
-		timetaken = ( timeGetTime() - m_TimeStarted ) / 1000;
+		timetaken = static_cast<int>((SystemTime.Get_Milliseconds() - m_TimeStarted) / 1000);
 
 		//////////if( m_BytesRead > 0 ) // NAK - RP said this is wrong
       if( ( m_BytesRead - m_StartPosition ) > 0 )

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWDownload/Download.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWDownload/Download.h
@@ -24,6 +24,7 @@
 //#include "../resource.h"       // main symbols
 #include "WWDownload/ftp.h"
 #include "WWDownload/downloaddefs.h"
+#include <cstdint>
 
 /////////////////////////////////////////////////////////////////////////////
 // CDownload
@@ -83,7 +84,7 @@ private:
 
 	char m_RegKey[ 256 ];
 	int  m_Status;
-	int  m_TimeStarted;
+	std::uint64_t  m_TimeStarted;
 	int  m_StartPosition;
 	int  m_FileSize;
 	int  m_BytesRead;

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/stimer.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/stimer.cpp
@@ -36,26 +36,16 @@
 
 #include	"always.h"
 #include	"stimer.h"
+#include	"systimer.h"
 #include	"win.h"
-
-#ifdef _MSC_VER
-#pragma warning (push,3)
-#endif
-
-#include "systimer.h"
-
-#ifdef _MSC_VER
-#pragma warning (pop)
-#endif
-
 
 long SystemTimerClass::operator () (void) const
 {
-	return TIMEGETTIME()/16;
+	return static_cast<long>(SystemTime.Get_Milliseconds() / 16);
 }
 
 
 SystemTimerClass::operator long (void) const
 {
-	return TIMEGETTIME()/16;
+	return static_cast<long>(SystemTime.Get_Milliseconds() / 16);
 }

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/systimer.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/systimer.cpp
@@ -53,10 +53,8 @@ SysTimeClass SystemTime;
  * HISTORY:                                                                                    *
  *   01/04/2003 : Created by Mark Wilczynski (EAP)                                             *
  *=============================================================================================*/
-SysTimeClass::SysTimeClass(void)
+SysTimeClass::SysTimeClass(void) : StartTime(clock_type::now())
 {
-	//tell windows we need single ms precision.
-	timeBeginPeriod(1);
 }
 
 /***********************************************************************************************
@@ -73,11 +71,7 @@ SysTimeClass::SysTimeClass(void)
  * HISTORY:                                                                                    *
  *   01/04/2003 : Created by Mark Wilczynski (EAP)                                             *
  *=============================================================================================*/
-SysTimeClass::~SysTimeClass(void)
-{
-	//tell windows we need single ms precision.
-	timeEndPeriod(1);
-}
+SysTimeClass::~SysTimeClass(void) = default;
 
 /***********************************************************************************************
  * SysTimeClass::Reset -- Reset class to good state                                            *
@@ -95,8 +89,7 @@ SysTimeClass::~SysTimeClass(void)
  *=============================================================================================*/
 void SysTimeClass::Reset(void)
 {
-	StartTime = timeGetTime();
-	WrapAdd = 0 - StartTime;
+	StartTime = clock_type::now();
 }
 
 
@@ -121,10 +114,7 @@ bool SysTimeClass::Is_Getting_Late(void)
 	** Even though the timers are all unsigned so we have a max time of 0xffffffff the game casts it to int in various places
 	** so it's safer to assume a signed max value.
 	*/
-	if (Get() > 0x6fffffff) {
-		return(true);
-	}
-	return(false);
+	return(Get_Milliseconds() > 0x6fffffffULL);
 }
 
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/systimer.h
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/WWLib/systimer.h
@@ -38,8 +38,8 @@
 #ifndef _SYSTIMER_H
 
 #include "always.h"
-#include <windows.h>
-#include "mmsys.h"
+#include <chrono>
+#include <cstdint>
 
 #define TIMEGETTIME SystemTime.Get
 #define MS_TIMER_SECOND 1000
@@ -54,12 +54,16 @@ class SysTimeClass
 
 	public:
 
+		using clock_type = std::chrono::steady_clock;
+		using duration_type = std::chrono::milliseconds;
+
 		SysTimeClass(void);	//default constructor
 		~SysTimeClass();	//default destructor
 
 		/*
 		** Get. Use everywhere you would use timeGetTime
 		*/
+		WWINLINE std::uint64_t Get_Milliseconds(void);
 		WWINLINE unsigned long Get(void);
 		WWINLINE unsigned long operator () (void) {return(Get());}
 		WWINLINE operator unsigned long(void) {return(Get());}
@@ -76,15 +80,12 @@ class SysTimeClass
 
 	private:
 
+		duration_type Get_Duration(void);
+
 		/*
 		** Time we were first called.
 		*/
-		unsigned long StartTime;
-
-		/*
-		** Time to add after timer wraps.
-		*/
-		unsigned long WrapAdd;
+		clock_type::time_point StartTime;
 
 };
 
@@ -105,7 +106,7 @@ extern SysTimeClass SystemTime;
  * HISTORY:                                                                                    *
  *   10/25/2001 1:38PM ST : Created                                                            *
  *=============================================================================================*/
-WWINLINE unsigned long SysTimeClass::Get(void)
+WWINLINE SysTimeClass::duration_type SysTimeClass::Get_Duration(void)
 {
 	/*
 	** This has to be static here since we don't know if we will get called in a global constructor of another object before our
@@ -118,15 +119,17 @@ WWINLINE unsigned long SysTimeClass::Get(void)
 		is_init = true;
 	}
 
-	unsigned long time = timeGetTime();
-	if (time > StartTime) {
-		return(time - StartTime);
-	}
+	return std::chrono::duration_cast<duration_type>(clock_type::now() - StartTime);
+}
 
-	/*
-	** Timer wrapped around. Eeek.
-	*/
-	return(time + WrapAdd);
+WWINLINE std::uint64_t SysTimeClass::Get_Milliseconds(void)
+{
+	return static_cast<std::uint64_t>(Get_Duration().count());
+}
+
+WWINLINE unsigned long SysTimeClass::Get(void)
+{
+	return static_cast<unsigned long>(Get_Milliseconds());
 }
 
 

--- a/GeneralsMD/Code/Libraries/Source/WWVegas/Wwutil/miscutil.cpp
+++ b/GeneralsMD/Code/Libraries/Source/WWVegas/Wwutil/miscutil.cpp
@@ -31,7 +31,6 @@
 #include "rawfile.h"
 #include "wwdebug.h"
 #include "win.h"
-#include "mmsys.h"
 #include "ffactory.h"
 
 //


### PR DESCRIPTION
## Summary
- swap the WWLib system timer implementation from Win32 multimedia timers to std::chrono so timing is portable and 64-bit aware
- add a 64-bit millisecond accessor and update dependent timing code to rely on the new API while removing mmsystem headers
- widen download timing state to 64 bits and drop unused multimedia header includes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce52f5d19883319219759b059068b2