### PR TITLE
Switch engine bootstrap to SFML and document Win32 dependencies

### DIFF
--- a/Generals/Code/GameEngineDevice/Source/SfmlDevice/Common/SfmlOSDisplay.cpp
+++ b/Generals/Code/GameEngineDevice/Source/SfmlDevice/Common/SfmlOSDisplay.cpp
@@ -1,0 +1,127 @@
+/*
+**      Command & Conquer Generals(tm)
+**      Copyright 2025 Electronic Arts Inc.
+**
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
+**
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
+**
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+//
+//  (c) 2001-2003 Electronic Arts Inc.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// FILE: SfmlOSDisplay.cpp /////////////////////////////////////////////////////
+//----------------------------------------------------------------------------- 
+//
+//  Cross-platform implementation of OSDisplayWarningBox built on top of the
+//  SFML bootstrap.  The legacy Win32 path surfaced modal MessageBox dialogs;
+//  this version falls back to terminal prompts while continuing to expose the
+//  same interface to the rest of the engine.
+//
+//----------------------------------------------------------------------------- 
+///////////////////////////////////////////////////////////////////////////////
+
+#include "Common/OSDisplay.h"
+
+#include "Common/AsciiString.h"
+#include "Common/UnicodeString.h"
+#include "GameClient/GameText.h"
+
+#include <cctype>
+#include <cstdio>
+#include <iostream>
+#include <string>
+
+#if defined(_WIN32)
+#include <io.h>
+#define SFML_OSDISPLAY_ISATTY _isatty
+#define SFML_OSDISPLAY_FILENO _fileno
+#else
+#include <unistd.h>
+#define SFML_OSDISPLAY_ISATTY isatty
+#define SFML_OSDISPLAY_FILENO fileno
+#endif
+
+namespace
+{
+
+Bool IsInteractiveTerminal()
+{
+        FILE *stream = stdin;
+        if (stream == NULL)
+        {
+                return FALSE;
+        }
+
+        return SFML_OSDISPLAY_ISATTY(SFML_OSDISPLAY_FILENO(stream)) ? TRUE : FALSE;
+}
+
+} // anonymous namespace
+
+OSDisplayButtonType OSDisplayWarningBox(AsciiString p, AsciiString m, UnsignedInt buttonFlags, UnsignedInt /*otherFlags*/)
+{
+        if (TheGameText == NULL)
+        {
+                return OSDBT_ERROR;
+        }
+
+        UnicodeString promptStr = TheGameText->fetch(p);
+        UnicodeString messageStr = TheGameText->fetch(m);
+
+        AsciiString promptAscii;
+        promptAscii.translate(promptStr);
+        AsciiString messageAscii;
+        messageAscii.translate(messageStr);
+
+        std::cerr << "[OSDisplay] " << promptAscii.str() << ": " << messageAscii.str() << std::endl;
+
+        const Bool allowCancel = (buttonFlags & OSDBT_CANCEL) != 0;
+        if (!allowCancel)
+        {
+                return OSDBT_OK;
+        }
+
+        if (!IsInteractiveTerminal())
+        {
+                std::cerr << "[OSDisplay] Non-interactive terminal detected; defaulting to OK" << std::endl;
+                return OSDBT_OK;
+        }
+
+        while (true)
+        {
+                std::cerr << "Confirm action? [y/N]: " << std::flush;
+                std::string response;
+                if (!std::getline(std::cin, response))
+                {
+                        return OSDBT_CANCEL;
+                }
+
+                if (response.empty())
+                {
+                        return OSDBT_OK;
+                }
+
+                const char ch = static_cast<char>(std::tolower(static_cast<unsigned char>(response[0])));
+                if (ch == 'y')
+                {
+                        return OSDBT_OK;
+                }
+                if (ch == 'n')
+                {
+                        return OSDBT_CANCEL;
+                }
+        }
+}
+

--- a/Generals/Code/Main/GameEngineFactory.cpp
+++ b/Generals/Code/Main/GameEngineFactory.cpp
@@ -19,7 +19,7 @@
 #include "WinMain.h"
 #include "Common/GameEngine.h"
 #include "Common/GameMemory.h"
-#include "Win32Device/Common/Win32GameEngine.h"
+#include "SfmlDevice/Common/SfmlGameEngine.h"
 
 Bool gInitialEngineActiveState = true;
 
@@ -51,7 +51,7 @@ GameEngine* CreateGameEngine(void)
 
         if (engine == NULL)
         {
-                engine = NEW Win32GameEngine;
+                engine = NEW SfmlGameEngine;
         }
 
         engine->setIsActive(gInitialEngineActiveState);

--- a/Generals/Code/Main/WinMain.cpp
+++ b/Generals/Code/Main/WinMain.cpp
@@ -93,7 +93,6 @@ Int APIENTRY WinMain(HINSTANCE, HINSTANCE, LPSTR, Int) {
 #include "GameClient/Mouse.h"
 #include "GameClient/IMEManager.h"
 #include "Win32Device/GameClient/Win32Mouse.h"
-#include "Win32Device/Common/Win32GameEngine.h"
 #include "W3DDevice/GameClient/RenderBackend.h"
 #include "SFMLPlatform/SfmlKeyboardBridge.h"
 #include <SFML/Window/Event.hpp>

--- a/GeneralsMD/Code/Main/WinMain.cpp
+++ b/GeneralsMD/Code/Main/WinMain.cpp
@@ -64,7 +64,7 @@
 #include "GameClient/Mouse.h"
 #include "GameClient/IMEManager.h"
 #include "Win32Device/GameClient/Win32Mouse.h"
-#include "Win32Device/Common/Win32GameEngine.h"
+#include "SfmlDevice/Common/SfmlGameEngine.h"
 #include "W3DDevice/GameClient/RenderBackend.h"
 #include "SFMLPlatform/SfmlKeyboardBridge.h"
 #include <SFML/Window/Event.hpp>
@@ -1415,17 +1415,17 @@ Int APIENTRY WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance,
 }  // end WinMain
 
 // CreateGameEngine ===========================================================
-/** Create the Win32 game engine we're going to use */
+/** Create the SFML-backed game engine we're going to use */
 //=============================================================================
 GameEngine *CreateGameEngine( void )
 {
-	Win32GameEngine *engine;
+        SfmlGameEngine *engine;
 
-	engine = NEW Win32GameEngine;
-	//game engine may not have existed when app got focus so make sure it
-	//knows about current focus state.
-	engine->setIsActive(isWinMainActive);
+        engine = NEW SfmlGameEngine;
+        //game engine may not have existed when app got focus so make sure it
+        //knows about current focus state.
+        engine->setIsActive(isWinMainActive);
 
-	return engine;
+        return engine;
 
 }  // end CreateGameEngine

--- a/docs/win32_device_consumer_inventory.md
+++ b/docs/win32_device_consumer_inventory.md
@@ -1,0 +1,28 @@
+# Win32 Device Consumer Inventory
+
+This document captures the remaining places in the open-source Command & Conquer Generals code base that reference the legacy Win32 device layer. The inventory was assembled by searching for the primary classes implemented under `Generals/Code/GameEngineDevice/Source/Win32Device` and `Win32Device/Common` and then recording every consumer that still includes or instantiates them.
+
+## Win32GameEngine
+
+* **Current status** – After switching the bootstrap to SFML, no production code paths outside the Win32 device subtree include the Win32 game engine implementation. Zero Hour’s launcher now constructs `SfmlGameEngine` directly.【F:GeneralsMD/Code/Main/WinMain.cpp†L60-L78】【F:GeneralsMD/Code/Main/WinMain.cpp†L1419-L1430】
+* **Implementation** – The original device implementation remains within the Win32 device source tree for reference.【F:Generals/Code/GameEngineDevice/Source/Win32Device/Common/Win32GameEngine.cpp†L33-L144】【F:Generals/Code/GameEngineDevice/Include/Win32Device/Common/Win32GameEngine.h†L25-L116】
+
+## Win32OSDisplay
+
+* **Legacy implementation** – The modal message-box wrapper continues to live in the Win32 device layer.【F:Generals/Code/GameEngineDevice/Source/Win32Device/Common/Win32OSDisplay.cpp†L25-L126】
+* **Runtime usage** – Game audio initialisation prompts still call `OSDisplayWarningBox`, which has now been reimplemented for the SFML platform layer but historically routed through the Win32 code.【F:Generals/Code/GameEngine/Source/Common/Audio/GameAudio.cpp†L247-L299】
+
+## Win32Mouse
+
+* **Application globals** – The top-level application state tracks the active mouse instance through the Win32-derived type.【F:Generals/Code/Main/ApplicationGlobals.cpp†L19-L34】
+* **Engine bootstrap** – The Windows entry point includes the Win32 mouse header so that the message pump can feed raw events into the mouse subsystem.【F:Generals/Code/Main/WinMain.cpp†L90-L101】
+* **W3D client** – The default mouse factory and the W3D-specific cursor implementation both derive from `Win32Mouse`, keeping the legacy behaviour in place for the renderer.【F:Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameClient.h†L53-L136】【F:Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DMouse.h†L54-L108】
+* **Tools** – Utilities such as WorldBuilder depend on the Win32 mouse implementation for their editor-specific input handling.【F:Generals/Code/Tools/WorldBuilder/src/WorldBuilder.cpp†L77-L108】
+
+## Win32DIMouse
+
+* **Inclusion** – The DirectInput flavoured mouse header is still included by the W3D game client, although the runtime now overrides mouse creation with the SFML-backed adapter.【F:Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DGameClient.h†L53-L135】
+* **Implementation** – The DirectInput wrapper itself continues to live in the Win32 device subtree.【F:Generals/Code/GameEngineDevice/Source/Win32Device/GameClient/Win32DIMouse.cpp†L19-L194】
+
+These references document the full set of touch points that need to be considered when removing or refactoring the remaining Win32-specific code paths.
+


### PR DESCRIPTION
## Summary
- add an SFML-backed implementation of `OSDisplayWarningBox` that mirrors the legacy Win32 API surface while emitting console prompts on non-interactive platforms
- update the runtime engine factory and Zero Hour launcher to create `SfmlGameEngine` instances by default, decoupling them from the Win32 device layer
- document the remaining Win32-dependent touch points across the repository for future cleanup

## Testing
- not run (build system unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ce584f1ce88331ba2bbdf5bbc27699