### PR TITLE
Refine SFML cursor management

### DIFF
--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DMouse.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DMouse.h
@@ -77,6 +77,14 @@ public:
 	virtual void draw( void );		///< draw the cursor or refresh the image
 	virtual void setRedrawMode(RedrawMode mode);	///<set cursor drawing method.
 
+	virtual void setVisibility(Bool visible);
+
+protected:
+	void updateCursorMetadata(MouseCursor cursor);
+	virtual void platformSetCursor(MouseCursor cursor);
+	virtual void platformClearCursor();
+	virtual void platformRestoreDefaultCursor();
+
 private:
 	MouseCursor m_currentD3DCursor;	///< keep track of last cursor image sent to D3D.
 	SurfaceClass *m_currentD3DSurface[MAX_2D_CURSOR_ANIM_FRAMES];

--- a/Generals/Code/SFMLPlatform/SfmlMouseBridge.h
+++ b/Generals/Code/SFMLPlatform/SfmlMouseBridge.h
@@ -39,6 +39,7 @@
 #include <deque>
 
 #include <SFML/Window/Mouse.hpp>
+#include <SFML/Window/Cursor.hpp>
 
 #include "W3DDevice/GameClient/W3DMouse.h"
 
@@ -61,6 +62,9 @@ public:
 
 protected:
         virtual UnsignedByte getMouseEvent( MouseIO *result, Bool flush );
+        virtual void platformSetCursor(MouseCursor cursor) override;
+        virtual void platformClearCursor() override;
+        virtual void platformRestoreDefaultCursor() override;
 
 private:
         enum ButtonIndex
@@ -90,6 +94,8 @@ private:
         std::deque< MouseIO > m_pendingEvents;
         ClickState m_clickState[ BUTTON_COUNT ];
         UnsignedInt m_doubleClickTime;
+        sf::Cursor m_arrowCursor;
+        bool m_arrowCursorValid;
 };
 
 SfmlMouseBridge *GetActiveMouseBridge();


### PR DESCRIPTION
## Summary
- load and cache the default SFML arrow cursor for the mouse bridge and manage cursor visibility through the window system
- override the W3D mouse platform hooks for the SFML build so cursor metadata is updated without calling Win32 helpers
- guard legacy Direct3D includes and cleanup paths so the bgfx/SFML configuration builds without Windows dependencies

## Testing
- make -j2 *(fails: missing SFML/Graphics/RenderWindow.hpp in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9f054c4483319442548746bc0f42