### PR TITLE
Refactor damage/death name tables into shared definitions

### DIFF
--- a/Generals/Code/GameEngine/Include/GameLogic/Damage.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/Damage.h
@@ -99,45 +99,7 @@ enum DamageType
 	DAMAGE_NUM_TYPES			// keep this last
 };
 
-#ifdef DEFINE_DAMAGE_NAMES
-static const char *TheDamageNames[] = 
-{
-	"EXPLOSION",			
-	"CRUSH",					
-	"ARMOR_PIERCING",
-	"SMALL_ARMS",		
-	"GATTLING",			
-	"RADIATION",			
-	"FLAME",					
-	"LASER",					
-	"SNIPER",				
-	"POISON",			
-	"HEALING",	
-	"UNRESISTABLE",	
-	"WATER",
-	"DEPLOY",	
-	"SURRENDER",	
-	"HACK",	
-	"KILL_PILOT",	
-	"PENALTY",	
-	"FALLING",	
-	"MELEE",	
-	"DISARM",	
-	"HAZARD_CLEANUP",	
-	"PARTICLE_BEAM",
-	"TOPPLING",
-	"INFANTRY_MISSILE",	
-	"AURORA_BOMB",	
-	"LAND_MINE",	
-	"JET_MISSILES",	
-	"STEALTHJET_MISSILES",	
-	"MOLOTOV_COCKTAIL",	
-	"COMANCHE_VULCAN",	
-	"FLESHY_SNIPER",	
-
-	NULL
-};
-#endif // end DEFINE_DAMAGE_NAMES
+extern const char *const TheDamageNames[DAMAGE_NUM_TYPES + 1];
 
 
 //-------------------------------------------------------------------------------------------------
@@ -199,34 +161,7 @@ enum DeathType
 	DEATH_NUM_TYPES			// keep this last
 };
 
-#ifdef DEFINE_DEATH_NAMES
-static const char *TheDeathNames[] = 
-{
-	"NORMAL",			
-	"NONE",			
-	"CRUSHED",					
-	"BURNED",		
-	"EXPLODED",
-	"POISONED",
-	"TOPPLED",
-	"FLOODED",
-	"SUICIDED",
-	"LASERED",
-	"DETONATED",
-	"SPLATTED",
-	"POISONED_BETA",	
-
-	"EXTRA_2",	
-	"EXTRA_3",	
-	"EXTRA_4",	
-	"EXTRA_5",	
-	"EXTRA_6",	
-	"EXTRA_7",	
-	"EXTRA_8",	
-
-	NULL
-};
-#endif // end DEFINE_DEATH_NAMES
+extern const char *const TheDeathNames[DEATH_NUM_TYPES + 1];
 
 
 //-------------------------------------------------------------------------------------------------

--- a/Generals/Code/GameEngine/Source/Common/DamageFX.cpp
+++ b/Generals/Code/GameEngine/Source/Common/DamageFX.cpp
@@ -31,7 +31,6 @@
 
 #include "PreRTS.h"	// This must go first in EVERY cpp file in the GameEngine
 
-#define DEFINE_DAMAGE_NAMES						// for DamageNames[]
 
 #include "Common/INI.h"
 #include "Common/ThingFactory.h"

--- a/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/Generals/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -29,8 +29,6 @@
 
 // INCLUDES ///////////////////////////////////////////////////////////////////////////////////////
 #include "PreRTS.h"	// This must go first in EVERY cpp file int the GameEngine
-#define DEFINE_DAMAGE_NAMES
-#define DEFINE_DEATH_NAMES
 
 #include "Common/INI.h"
 #include "Common/INIException.h"

--- a/Generals/Code/GameEngine/Source/GameLogic/Damage.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Damage.cpp
@@ -1,0 +1,105 @@
+/*
+**      Command & Conquer Generals(tm)
+**      Copyright 2025 Electronic Arts Inc.
+**
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
+**
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
+**
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                                                                             /
+/
+//  (c) 2001-2003 Electronic Arts Inc.                                                                                         /
+/
+//                                                                                                                             /
+/
+////////////////////////////////////////////////////////////////////////////////
+
+// FILE: Damage.cpp ////////////////////////////////////////////////////////////////////////////
+// Desc:   Shared damage/death name tables
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+// INCLUDES ///////////////////////////////////////////////////////////////////////////////////////
+#include "PreRTS.h"     // This must go first in EVERY cpp file in the GameEngine
+
+#include "GameLogic/Damage.h"
+
+const char *const TheDamageNames[DAMAGE_NUM_TYPES + 1] =
+{
+        "EXPLOSION",
+        "CRUSH",
+        "ARMOR_PIERCING",
+        "SMALL_ARMS",
+        "GATTLING",
+        "RADIATION",
+        "FLAME",
+        "LASER",
+        "SNIPER",
+        "POISON",
+        "HEALING",
+        "UNRESISTABLE",
+        "WATER",
+        "DEPLOY",
+        "SURRENDER",
+        "HACK",
+        "KILL_PILOT",
+        "PENALTY",
+        "FALLING",
+        "MELEE",
+        "DISARM",
+        "HAZARD_CLEANUP",
+        "PARTICLE_BEAM",
+        "TOPPLING",
+        "INFANTRY_MISSILE",
+        "AURORA_BOMB",
+        "LAND_MINE",
+        "JET_MISSILES",
+        "STEALTHJET_MISSILES",
+        "MOLOTOV_COCKTAIL",
+        "COMANCHE_VULCAN",
+        "FLESHY_SNIPER",
+
+        NULL
+};
+
+const char *const TheDeathNames[DEATH_NUM_TYPES + 1] =
+{
+        "NORMAL",
+        "NONE",
+        "CRUSHED",
+        "BURNED",
+        "EXPLODED",
+        "POISONED",
+        "TOPPLED",
+        "FLOODED",
+        "SUICIDED",
+        "LASERED",
+        "DETONATED",
+        "SPLATTED",
+        "POISONED_BETA",
+
+        "EXTRA_2",
+        "EXTRA_3",
+        "EXTRA_4",
+        "EXTRA_5",
+        "EXTRA_6",
+        "EXTRA_7",
+        "EXTRA_8",
+
+        NULL
+};
+
+static_assert((sizeof(TheDamageNames) / sizeof(*TheDamageNames)) == DAMAGE_NUM_TYPES + 1,
+        "TheDamageNames must match DAMAGE_NUM_TYPES plus terminator");
+static_assert((sizeof(TheDeathNames) / sizeof(*TheDeathNames)) == DEATH_NUM_TYPES + 1,
+        "TheDeathNames must match DEATH_NUM_TYPES plus terminator");

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Armor.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Armor.cpp
@@ -30,7 +30,6 @@
 // INCLUDES ///////////////////////////////////////////////////////////////////////////////////////
 #include "PreRTS.h"	// This must go first in EVERY cpp file int the GameEngine
 
-#define DEFINE_DAMAGE_NAMES						// for DamageNames[]
 
 #include "Common/INI.h"
 #include "Common/ThingFactory.h"

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Die/FXListDie.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Die/FXListDie.cpp
@@ -31,7 +31,6 @@
 // INCLUDES ///////////////////////////////////////////////////////////////////////////////////////
 #include "PreRTS.h"	// This must go first in EVERY cpp file int the GameEngine
 
-#define DEFINE_DAMAGE_NAMES
 #include "Common/INI.h"
 #include "Common/ThingTemplate.h"
 #include "Common/Xfer.h"

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -29,8 +29,6 @@
 
 #include "PreRTS.h"	// This must go first in EVERY cpp file int the GameEngine
 
-#define DEFINE_DAMAGE_NAMES
-#define DEFINE_DEATH_NAMES
 
 // INCLUDES ///////////////////////////////////////////////////////////////////////////////////////
 #include "Common\ThingTemplate.h"

--- a/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/Generals/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -30,8 +30,6 @@
 // INCLUDES ///////////////////////////////////////////////////////////////////////////////////////
 #include "PreRTS.h"	// This must go first in EVERY cpp file int the GameEngine
 
-#define DEFINE_DAMAGE_NAMES
-#define DEFINE_DEATH_NAMES
 #define DEFINE_WEAPONBONUSCONDITION_NAMES
 #define DEFINE_WEAPONBONUSFIELD_NAMES
 #define DEFINE_WEAPONCOLLIDEMASK_NAMES

--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/Damage.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/Damage.h
@@ -198,34 +198,7 @@ enum DeathType
 	DEATH_NUM_TYPES			// keep this last
 };
 
-#ifdef DEFINE_DEATH_NAMES
-static const char *TheDeathNames[] = 
-{
-	"NORMAL",			
-	"NONE",			
-	"CRUSHED",					
-	"BURNED",		
-	"EXPLODED",
-	"POISONED",
-	"TOPPLED",
-	"FLOODED",
-	"SUICIDED",
-	"LASERED",
-	"DETONATED",
-	"SPLATTED",
-	"POISONED_BETA",	
-	"EXTRA_2",	
-	"EXTRA_3",	
-	"EXTRA_4",	
-	"EXTRA_5",	
-	"EXTRA_6",	
-	"EXTRA_7",	
-	"EXTRA_8",	
-	"POISONED_GAMMA",	
-
-	NULL
-};
-#endif // end DEFINE_DEATH_NAMES
+extern const char *const TheDeathNames[DEATH_NUM_TYPES + 1];
 
 
 //-------------------------------------------------------------------------------------------------

--- a/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/INI/INI.cpp
@@ -29,7 +29,6 @@
 
 // INCLUDES ///////////////////////////////////////////////////////////////////////////////////////
 #include "PreRTS.h"	// This must go first in EVERY cpp file int the GameEngine
-#define DEFINE_DEATH_NAMES
 
 #include "Common/INI.h"
 #include "Common/INIException.h"

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/ParticleUplinkCannonUpdate.cpp
@@ -29,7 +29,6 @@
 
 #include "PreRTS.h"	// This must go first in EVERY cpp file int the GameEngine
 
-#define DEFINE_DEATH_NAMES
 
 // INCLUDES ///////////////////////////////////////////////////////////////////////////////////////
 #include "Common\ThingTemplate.h"

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipDeploymentUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipDeploymentUpdate.cpp
@@ -29,7 +29,6 @@
 
 #include "PreRTS.h"	// This must go first in EVERY cpp file int the GameEngine
 
-#define DEFINE_DEATH_NAMES
 
 // INCLUDES ///////////////////////////////////////////////////////////////////////////////////////
 #include "Common\ThingTemplate.h"

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipUpdate.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Update/SpectreGunshipUpdate.cpp
@@ -29,7 +29,6 @@
 
 #include "PreRTS.h"	// This must go first in EVERY cpp file int the GameEngine
 
-#define DEFINE_DEATH_NAMES
 
 // INCLUDES ///////////////////////////////////////////////////////////////////////////////////////
 #include "Common\GameAudio.h"

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/Object/Weapon.cpp
@@ -30,7 +30,6 @@
 // INCLUDES ///////////////////////////////////////////////////////////////////////////////////////
 #include "PreRTS.h"	// This must go first in EVERY cpp file int the GameEngine
 
-#define DEFINE_DEATH_NAMES
 #define DEFINE_WEAPONBONUSCONDITION_NAMES
 #define DEFINE_WEAPONBONUSFIELD_NAMES
 #define DEFINE_WEAPONCOLLIDEMASK_NAMES

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/Damage.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/Damage.cpp
@@ -39,9 +39,9 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-const char* DamageTypeFlags::s_bitNameList[] = 
+const char* DamageTypeFlags::s_bitNameList[] =
 {
-	"EXPLOSION",			
+        "EXPLOSION",
 	"CRUSH",					
 	"ARMOR_PIERCING",
 	"SMALL_ARMS",		
@@ -80,8 +80,38 @@ const char* DamageTypeFlags::s_bitNameList[] =
 	"KILL_GARRISONED",
 	"STATUS",
 
-	NULL
+        NULL
 };
+
+const char *const TheDeathNames[DEATH_NUM_TYPES + 1] =
+{
+        "NORMAL",
+        "NONE",
+        "CRUSHED",
+        "BURNED",
+        "EXPLODED",
+        "POISONED",
+        "TOPPLED",
+        "FLOODED",
+        "SUICIDED",
+        "LASERED",
+        "DETONATED",
+        "SPLATTED",
+        "POISONED_BETA",
+        "EXTRA_2",
+        "EXTRA_3",
+        "EXTRA_4",
+        "EXTRA_5",
+        "EXTRA_6",
+        "EXTRA_7",
+        "EXTRA_8",
+        "POISONED_GAMMA",
+
+        NULL
+};
+
+static_assert((sizeof(TheDeathNames) / sizeof(*TheDeathNames)) == DEATH_NUM_TYPES + 1,
+        "TheDeathNames must match DEATH_NUM_TYPES plus terminator");
 
 DamageTypeFlags DAMAGE_TYPE_FLAGS_NONE; 	// inits to all zeroes
 DamageTypeFlags DAMAGE_TYPE_FLAGS_ALL;


### PR DESCRIPTION
## Summary
- expose TheDamageNames/TheDeathNames as shared declarations in Damage.h
- add GameLogic/Damage.cpp to define the arrays once and remove ad-hoc macro instantiations
- mirror the change for Zero Hour by defining TheDeathNames alongside DamageTypeFlags

## Testing
- `make build/bin/generals-sfml` *(fails: Generals/Code/GameEngine/Source/Common/GameEngine.cpp:45:10: fatal error: Common/File.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68cedc689b1c83319951ad2604adecd5