### PR TITLE
Improve cross-platform build includes and audio bridge

### DIFF
--- a/Generals/Code/GameEngine/Include/Common/GameCommon.h
+++ b/Generals/Code/GameEngine/Include/Common/GameCommon.h
@@ -299,7 +299,7 @@ public:																																								\
 	inline DLINK_ITERATOR<OBJCLASS> iterate_##LISTNAME() const													\
 	{																																										\
 		DEBUG_ASSERTCRASH(!BOGUSPTR(m_dlinkhead_##LISTNAME.m_head), ("bogus head ptr"));	\
-		return DLINK_ITERATOR<OBJCLASS>(m_dlinkhead_##LISTNAME.m_head, OBJCLASS::dlink_next_##LISTNAME);	\
+		return DLINK_ITERATOR<OBJCLASS>(m_dlinkhead_##LISTNAME.m_head, &OBJCLASS::dlink_next_##LISTNAME);	\
 	}																																										\
 	inline OBJCLASS *getFirstItemIn_##LISTNAME() const																	\
 	{																																										\

--- a/Generals/Code/GameEngine/Include/GameLogic/PartitionManager.h
+++ b/Generals/Code/GameEngine/Include/GameLogic/PartitionManager.h
@@ -514,11 +514,15 @@ public:
 	ObjectShroudStatus getShroudedStatus(Int playerIndex);
 
 	inline Int wasSeenByAnyPlayers() const	///<check if a player in the game has seen the object but is now looking at fogged version.
-	{	
-		for (Int i=0; i<MAX_PLAYER_COUNT; i++)
-			if (m_everSeenByPlayer[i] && m_shroudedness[i] == OBJECTSHROUD_FOGGED)
-				return i;
-		return i;
+	{
+		for (Int playerIndex = 0; playerIndex < MAX_PLAYER_COUNT; ++playerIndex)
+		{
+			if (m_everSeenByPlayer[playerIndex] && m_shroudedness[playerIndex] == OBJECTSHROUD_FOGGED)
+			{
+				return playerIndex;
+			}
+		}
+		return -1;
 	}
 
 
@@ -1225,7 +1229,7 @@ protected:
 		This is an internal function that is used to implement the public 
 		getClosestObject and iterateObjects calls. 
 	*/
-	Object *PartitionManager::getClosestObjects(
+	Object *getClosestObjects(
 		const Object *obj, 
 		const Coord3D *pos, 
 		Real maxDist, 

--- a/Generals/Code/GameEngine/Include/wpaudio/altypes.h
+++ b/Generals/Code/GameEngine/Include/wpaudio/altypes.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "always.h"
+#include "Lib/BaseType.h"
 
 #include <algorithm>
 #include <chrono>

--- a/Generals/Code/GameEngine/Source/Common/Audio/GameSpeech.cpp
+++ b/Generals/Code/GameEngine/Source/Common/Audio/GameSpeech.cpp
@@ -39,11 +39,11 @@
 
 #include "wpaudio/attributes.h"
 
-#include "wsys/File.h"
-#include "wsys/List.h"
+#include "Common/file.h"
+#include "Common/List.h"
 #include "wpaudio/Streamer.h"
 #include "wpaudio/Time.h"
-#include "wpaudio/Device.h"
+#include "wpaudio/device.h"
 #include "wpaudio/Streamer.h"
 
 #define DEFINE_DLG_EVENT_PRIORITY_NAMES

--- a/Generals/Code/Libraries/Include/Lib/BaseType.h
+++ b/Generals/Code/Libraries/Include/Lib/BaseType.h
@@ -244,8 +244,8 @@ struct RealRange
 	// both ranges
 	void combine( RealRange &other )
 	{
-		lo = min( lo, other.lo );
-		hi = max( hi, other.hi );
+                lo = std::min(lo, other.lo);
+                hi = std::max(hi, other.hi);
 	}
 };
 

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/always.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/always.h
@@ -41,6 +41,11 @@
 #define ALWAYS_H
 
 #include <assert.h>
+#include <cstddef>
+
+#ifndef __cdecl
+#define __cdecl
+#endif
 
 // Disable warning about exception handling not being enabled. It's used as part of STL - in a part of STL we don't use.
 #ifdef _MSC_VER
@@ -73,6 +78,7 @@
 #endif	//_MSC_VER
 #endif	//_DEBUG
 
+#ifdef _MSC_VER
 #ifndef _OPERATOR_NEW_DEFINED_
 
 	#define _OPERATOR_NEW_DEFINED_
@@ -97,6 +103,7 @@
 	inline void __cdecl operator delete[]					(void *, void *p)		{ }
 
 #endif
+#endif // _MSC_VER
 
 #if (defined(_DEBUG) || defined(_INTERNAL)) 
 	#define MSGW3DNEW(MSG)					new( MSG, 0 )

--- a/Generals/Code/SFMLPlatform/SfmlAudioManager.cpp
+++ b/Generals/Code/SFMLPlatform/SfmlAudioManager.cpp
@@ -30,6 +30,7 @@
 #include <cmath>
 #include <condition_variable>
 #include <cstdio>
+#include <cstring>
 #include <deque>
 #include <limits>
 #include <mutex>
@@ -172,9 +173,9 @@ public:
     void onFrameDecoded(void*) override {}
 
 private:
-    static unsigned handleSetup(void** opaque, char* format, unsigned* rate, unsigned* channels) {
+    static int handleSetup(void** opaque, char* format, unsigned* rate, unsigned* channels) {
         if (!opaque || !*opaque || !format || !rate || !channels) {
-            return 0;
+            return -1;
         }
 
         auto* self = static_cast<SfmlVlcAudioBridge*>(*opaque);
@@ -185,10 +186,10 @@ private:
         self->m_stream.reset(new SfmlVideoAudioStream());
         if (!self->m_stream->initializeStream(self->m_channelCount, self->m_sampleRate)) {
             self->m_stream.reset();
-            return 0;
+            return -1;
         }
         self->m_stream->play();
-        return 1;
+        return 0;
     }
 
     static void handleCleanup(void* opaque) {

--- a/Generals/Code/compat/win_compat.h
+++ b/Generals/Code/compat/win_compat.h
@@ -49,6 +49,14 @@ using LPWSTR = wchar_t*;
 using LPCWSTR = const wchar_t*;
 using WCHAR = wchar_t;
 
+#ifndef TRUE
+#define TRUE 1
+#endif
+
+#ifndef FALSE
+#define FALSE 0
+#endif
+
 struct _EXCEPTION_POINTERS;
 using EXCEPTION_POINTERS = _EXCEPTION_POINTERS;
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,21 @@ BIN_DIR     := $(BUILD_DIR)/bin
 LIB_DIR     := $(BUILD_DIR)/lib
 TARGET      ?= $(BIN_DIR)/generals-sfml$(EXEEXT)
 
+# Core include search paths shared by every module
+INCLUDE_DIRS := \
+        $(SRC_DIR) \
+        $(SRC_DIR)/GameEngine/Include \
+        $(SRC_DIR)/GameEngine/Include/Precompiled \
+        $(SRC_DIR)/GameEngineDevice/Include \
+        $(SRC_DIR)/Libraries/Include \
+        $(SRC_DIR)/Libraries/Source/WWVegas/WWLib \
+        $(SRC_DIR)/Libraries/Source/WWVegas/WWMath \
+        $(SRC_DIR)/Libraries/Source/WWVegas \
+        $(SRC_DIR)/Main \
+        $(SRC_DIR)/Main/Include
+
+CPPFLAGS += $(addprefix -I,$(INCLUDE_DIRS))
+
 # --- snip: your include-path setup unchanged ---
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
* add a single Makefile include list so every module can find the shared SFML/libVLC and GameEngine headers when compiling on non-Windows toolchains
* normalise several legacy headers for cross-platform use (guard `__cdecl`, include `<cstddef>`, pull in `Lib/BaseType.h`, and fix pointer-to-member usage/macros) to unblock more of the GameEngine sources during GCC/Clang builds
* harden the SFML/VLC audio glue to use the correct libVLC callback signature and standard library headers
* extend the Win32 compatibility shim with TRUE/FALSE definitions so our compat layer works with POSIX compilers
* point GameSpeech at the modern Common/ headers instead of the missing wsys/ variants

## Testing
* `make build/lib/libSFMLPlatform.a`
* `make build/lib/libcompat.a`
* `make build/lib/libMain.a`


------
https://chatgpt.com/codex/tasks/task_e_68cef564b6208331b3da625af5eb3607