### PR TITLE
Fix clean-related targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ TOTAL_C_SOURCE_COUNT   := $(words $(C_SOURCES))
 # -----------------------------------------------------------------------------
 # Build rules
 # -----------------------------------------------------------------------------
-.PHONY: all clean distclean print-config install-deps relink
+.PHONY: all clean fclean distclean re print-config install-deps relink
 
 # Loud error if nothing to build
 ifeq ($(strip $(TOTAL_CPP_SOURCE_COUNT) $(TOTAL_C_SOURCE_COUNT)),)
@@ -207,10 +207,15 @@ relink:
 	$(MAKE) $(MAKEFLAGS) $(TARGET)
 
 clean:
-	rm -rf $(OBJ_DIR)
+	@if [ -n "$(BUILD_DIR)" ]; then rm -rf "$(BUILD_DIR)"; fi
 
-distclean: clean
+fclean: clean
 	@rm -f "$(TARGET)"
+
+distclean: fclean
+
+re: fclean
+	$(MAKE) $(MAKEFLAGS) all
 
 # Best-effort dependency installer for common development environments.
 install-deps:


### PR DESCRIPTION
## Summary
- update the Makefile clean target to remove the entire build directory safely
- add distinct fclean and re targets and hook distclean through fclean
- extend the phony target list to cover the new clean targets

## Testing
- make clean
- make fclean

------
https://chatgpt.com/codex/tasks/task_e_68cefe26d0f48331a01ce37828c38f5f