### PR TITLE
Add peer messaging stub and Linux guards for matchbot

### DIFF
--- a/Generals/Code/Tools/matchbot/generals.cpp
+++ b/Generals/Code/Tools/matchbot/generals.cpp
@@ -16,22 +16,21 @@
 **	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__unix__) && !defined(__APPLE__)
 #include <process.h>
 #endif
 
-#include <wstring.h>
-#include <tcp.h>
-#include <wdebug.h>
+#include "wlib/wstring.h"
+#include "wnet/tcp.h"
+#include "wlib/wdebug.h"
 #include "mydebug.h"
 
-#include <ghttp/ghttp.h>
 
 #include <cmath>
 #include <cstdlib>
 #include <algorithm>
 
-#ifdef _UNIX
+#if defined(__unix__) || defined(__APPLE__) || defined(__linux__)
 using namespace std;
 #endif
 

--- a/Generals/Code/Tools/matchbot/generals.h
+++ b/Generals/Code/Tools/matchbot/generals.h
@@ -19,7 +19,7 @@
 #ifndef __GENERALS_H__
 #define __GENERALS_H__
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__unix__) && !defined(__APPLE__)
 #include <process.h>
 #endif
 //#include <wstring.h>

--- a/Generals/Code/Tools/matchbot/global.h
+++ b/Generals/Code/Tools/matchbot/global.h
@@ -19,18 +19,18 @@
 #ifndef __GLOBAL_H__
 #define __GLOBAL_H__
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__unix__) && !defined(__APPLE__)
 #include <process.h>
 #ifdef IN
 #undef IN
 #endif
 #define IN const
 #endif
-#include <wstypes.h>
-#include <configfile.h>
-#include <critsec.h>
-#include <threadfac.h>
-#include <tcp.h>
+#include "wlib/wstypes.h"
+#include "wlib/configfile.h"
+#include "wlib/critsec.h"
+#include "wlib/threadfac.h"
+#include "wnet/tcp.h"
 #include "matcher.h"
 #include "rand.h"
 

--- a/Generals/Code/Tools/matchbot/matcher.cpp
+++ b/Generals/Code/Tools/matchbot/matcher.cpp
@@ -19,7 +19,7 @@
 #include "global.h"
 #include "matcher.h"
 #include "encrypt.h"
-#include "timezone.h"
+#include "wlib/timezone.h"
 #include "debug.h"
 
 #ifdef _WINDOWS

--- a/Generals/Code/Tools/matchbot/matcher.h
+++ b/Generals/Code/Tools/matchbot/matcher.h
@@ -19,19 +19,19 @@
 #ifndef __MATCHER_H__
 #define __MATCHER_H__
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__unix__) && !defined(__APPLE__)
 #include <process.h>
 #endif
-#include <configfile.h>
-#include <critsec.h>
-#include <threadfac.h>
-#include <tcp.h>
+#include "wlib/configfile.h"
+#include "wlib/critsec.h"
+#include "wlib/threadfac.h"
+#include "wnet/tcp.h"
 #include <cstdarg>
-#include <sem4.h>
+#include "wlib/sem4.h"
 
 #include <string>
 
-#include <peer/peer.h>
+#include "peer/peer.h"
 
 class MatcherClass
 {

--- a/Generals/Code/Tools/matchbot/mydebug.h
+++ b/Generals/Code/Tools/matchbot/mydebug.h
@@ -55,23 +55,23 @@ will you be ready to leave grasshopper.
 
 #define USE_SEM
 
-#include "wstypes.h"
+#include "wlib/wstypes.h"
 
-#ifdef _WINDOWS
+#if defined(_WIN32) && !defined(__unix__) && !defined(__APPLE__)
 #include <windows.h>
 #endif
 #include <iostream>
 
 #ifdef USE_SEM
-#include "sem4.h"
+#include "wlib/sem4.h"
 #else
-#include "critsec.h"
+#include "wlib/critsec.h"
 #endif
-#include "odevice.h"
-#include "streamer.h"
-#include "xtime.h"
-#include "timezone.h" // MDC
-#include "filed.h"
+#include "wlib/odevice.h"
+#include "wlib/streamer.h"
+#include "wlib/xtime.h"
+#include "wlib/timezone.h" // MDC
+#include "wlib/filed.h"
 
 // This is needed because the streams return a pointer.  Every time you
 //  change the output device the old stream is deleted, and a new one

--- a/Generals/Code/Tools/matchbot/peer/peer.cpp
+++ b/Generals/Code/Tools/matchbot/peer/peer.cpp
@@ -1,0 +1,163 @@
+/*
+**      Command & Conquer Generals(tm)
+**      Copyright 2025 Electronic Arts Inc.
+**
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
+**
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
+**
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "peer.h"
+
+#include <cstring>
+
+struct PeerContext {
+    PEERCallbacks callbacks{};
+    bool connected{false};
+};
+
+PEER peerInitialize(const PEERCallbacks* callbacks)
+{
+    PeerContext* context = new PeerContext();
+    if (callbacks) {
+        context->callbacks = *callbacks;
+    }
+    context->connected = false;
+    return context;
+}
+
+void peerShutdown(PEER peer)
+{
+    delete peer;
+}
+
+void peerDisconnect(PEER peer)
+{
+    if (!peer) {
+        return;
+    }
+    peer->connected = false;
+    if (peer->callbacks.disconnected) {
+        peer->callbacks.disconnected(peer, "disconnected", peer->callbacks.param);
+    }
+}
+
+void peerThink(PEER)
+{
+    // No background processing required for the stub implementation.
+}
+
+PEERBool peerIsConnected(PEER peer)
+{
+    return (peer && peer->connected) ? PEERTrue : PEERFalse;
+}
+
+PEERBool peerSetTitle(PEER,
+                      const char*,
+                      const char*,
+                      const char*,
+                      const char*,
+                      int,
+                      int,
+                      PEERBool,
+                      const PEERBool*,
+                      const PEERBool*)
+{
+    return PEERTrue;
+}
+
+void peerConnect(PEER peer,
+                 const char*,
+                 int,
+                 void (*nickError)(PEER, int, const char*, void*),
+                 void (*connectCallback)(PEER, PEERBool, void*),
+                 void* param,
+                 PEERBool)
+{
+    if (!peer) {
+        return;
+    }
+
+    peer->connected = true;
+    if (connectCallback) {
+        connectCallback(peer, PEERTrue, param);
+    }
+    // Notify the registered callback structure as well, if provided.
+    if (peer->callbacks.disconnected == nullptr) {
+        (void)nickError;
+    }
+}
+
+void peerRetryWithNick(PEER, const char*)
+{
+    // Nothing to do for the stub implementation.
+}
+
+void peerAuthenticateCDKey(PEER peer,
+                           const char*,
+                           void (*callback)(PEER, int, const char*, void*),
+                           void* param,
+                           PEERBool)
+{
+    if (callback) {
+        callback(peer, 1, "", param);
+    }
+}
+
+void peerListGroupRooms(PEER peer,
+                        const char*,
+                        void (*callback)(PEER, PEERBool, int, SBServer, const char*,
+                                         int, int, int, int, void*),
+                        void* param,
+                        PEERBool)
+{
+    if (callback) {
+        callback(peer, PEERTrue, 1, nullptr, "QuickMatch", 0, 0, 0, 0, param);
+    }
+}
+
+void peerJoinGroupRoom(PEER peer,
+                       int,
+                       void (*callback)(PEER, PEERBool, PEERJoinResult, RoomType, void*),
+                       void* param,
+                       PEERBool)
+{
+    if (callback) {
+        callback(peer, PEERTrue, PEERJoinResult_Success, GroupRoom, param);
+    }
+}
+
+void peerEnumPlayers(PEER peer,
+                     RoomType room,
+                     void (*callback)(PEER, PEERBool, RoomType, int, const char*, int, void*),
+                     void* param)
+{
+    if (callback) {
+        callback(peer, PEERFalse, room, -1, nullptr, 0, param);
+    }
+}
+
+void peerMessagePlayer(PEER peer,
+                       const char* nick,
+                       const char* message,
+                       MessageType messageType)
+{
+    (void)nick;
+    (void)message;
+    (void)messageType;
+
+    (void)peer;
+
+    // In the original GameSpy SDK this would deliver a private message to
+    // another player.  The stub has no networking backend, so the call is a
+    // no-op beyond parameter validation.
+}

--- a/Generals/Code/Tools/matchbot/peer/peer.h
+++ b/Generals/Code/Tools/matchbot/peer/peer.h
@@ -1,0 +1,126 @@
+/*
+**      Command & Conquer Generals(tm)
+**      Copyright 2025 Electronic Arts Inc.
+**
+**      This program is free software: you can redistribute it and/or modify
+**      it under the terms of the GNU General Public License as published by
+**      the Free Software Foundation, either version 3 of the License, or
+**      (at your option) any later version.
+**
+**      This program is distributed in the hope that it will be useful,
+**      but WITHOUT ANY WARRANTY; without even the implied warranty of
+**      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**      GNU General Public License for more details.
+**
+**      You should have received a copy of the GNU General Public License
+**      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef MATCHBOT_PEER_PEER_H
+#define MATCHBOT_PEER_PEER_H
+
+#include <cstddef>
+
+enum RoomType {
+    TitleRoom,
+    GroupRoom,
+    StagingRoom
+};
+
+enum MessageType {
+    NormalMessage = 0,
+    ActionMessage = 1,
+    NoticeMessage = 2,
+
+    // Legacy aliases retained for compatibility with existing code.
+    MessageType_Normal = NormalMessage,
+    MessageType_Action = ActionMessage,
+    MessageType_Notice = NoticeMessage
+};
+
+enum PEERJoinResult {
+    PEERJoinResult_Success
+};
+
+using SBServer = void*;
+
+using PEERBool = int;
+constexpr PEERBool PEERTrue = 1;
+constexpr PEERBool PEERFalse = 0;
+
+using CHAT = void*;
+using CHATBool = int;
+constexpr CHATBool CHATTrue = 1;
+constexpr CHATBool CHATFalse = 0;
+
+struct PeerContext;
+using PEER = PeerContext*;
+
+struct PEERCallbacks {
+    void (*disconnected)(PEER, const char*, void*);
+    void (*playerChangedNick)(PEER, RoomType, const char*, const char*, void*);
+    void (*playerJoined)(PEER, RoomType, const char*, void*);
+    void (*playerLeft)(PEER, RoomType, const char*, const char*, void*);
+    void (*roomMessage)(PEER, RoomType, const char*, const char*, MessageType, void*);
+    void (*playerMessage)(PEER, const char*, const char*, MessageType, void*);
+    void* param;
+};
+
+PEER peerInitialize(const PEERCallbacks* callbacks);
+void peerShutdown(PEER peer);
+void peerDisconnect(PEER peer);
+
+void peerThink(PEER peer);
+PEERBool peerIsConnected(PEER peer);
+
+PEERBool peerSetTitle(PEER peer,
+                      const char* title,
+                      const char* secretKey,
+                      const char* productID,
+                      const char* uniques,
+                      int availableRooms,
+                      int maxPlayers,
+                      PEERBool persist,
+                      const PEERBool* pingRooms,
+                      const PEERBool* crossPingRooms);
+
+void peerConnect(PEER peer,
+                 const char* nick,
+                 int profileID,
+                 void (*nickError)(PEER, int, const char*, void*),
+                 void (*connectCallback)(PEER, PEERBool, void*),
+                 void* param,
+                 PEERBool blocking);
+
+void peerRetryWithNick(PEER peer, const char* nick);
+
+void peerAuthenticateCDKey(PEER peer,
+                           const char* cdKey,
+                           void (*callback)(PEER, int, const char*, void*),
+                           void* param,
+                           PEERBool blocking);
+
+void peerListGroupRooms(PEER peer,
+                        const char* filter,
+                        void (*callback)(PEER, PEERBool, int, SBServer, const char*,
+                                         int, int, int, int, void*),
+                        void* param,
+                        PEERBool blocking);
+
+void peerJoinGroupRoom(PEER peer,
+                       int groupID,
+                       void (*callback)(PEER, PEERBool, PEERJoinResult, RoomType, void*),
+                       void* param,
+                       PEERBool blocking);
+
+void peerEnumPlayers(PEER peer,
+                     RoomType room,
+                     void (*callback)(PEER, PEERBool, RoomType, int, const char*, int, void*),
+                     void* param);
+
+void peerMessagePlayer(PEER peer,
+                       const char* nick,
+                       const char* message,
+                       MessageType messageType);
+
+#endif // MATCHBOT_PEER_PEER_H

--- a/Generals/Code/Tools/matchbot/wlib/arraylist.h
+++ b/Generals/Code/Tools/matchbot/wlib/arraylist.h
@@ -51,7 +51,7 @@ that don't belong to them, etc...
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
-#include <new.h>
+#include <new>
 #include <math.h>
 
 #include "wstypes.h"

--- a/Generals/Code/Tools/matchbot/wlib/critsec.cpp
+++ b/Generals/Code/Tools/matchbot/wlib/critsec.cpp
@@ -18,25 +18,25 @@
 
 #include "critsec.h"
 #include <assert.h>
-#include "wlib/wdebug.h"
+#include "wdebug.h"
 
 
 
 CritSec::CritSec()
 {
-#ifdef _UNIX
+#if !CRITSEC_PLATFORM_WINDOWS
   pthread_mutex_init(&Mutex_, NULL);
   RefCount_ = 0;
-#elif defined(_WIN32)
+#elif CRITSEC_PLATFORM_WINDOWS
   InitializeCriticalSection(&CritSec_);
 #endif
 }
 
 CritSec::~CritSec()
 {
- #ifdef _UNIX
+ #if !CRITSEC_PLATFORM_WINDOWS
    pthread_mutex_destroy(&Mutex_);
- #elif defined(_WIN32)
+ #elif CRITSEC_PLATFORM_WINDOWS
    DeleteCriticalSection(&CritSec_);
  #endif
 }
@@ -51,7 +51,7 @@ CritSec::~CritSec()
 //
 sint32 CritSec::lock(int *refcount) RO 
 {
- #ifdef _UNIX
+ #if !CRITSEC_PLATFORM_WINDOWS
     sint32	status;
 
     // I TRY to get the lock. IF I succeed, OR if I fail because
@@ -83,19 +83,17 @@ sint32 CritSec::lock(int *refcount) RO
       *refcount=RefCount_;
 
     return(status);
- #elif defined(_WIN32)
+ #elif CRITSEC_PLATFORM_WINDOWS
    // TOFIX update the refcount
    EnterCriticalSection(&CritSec_);
    return(0);
-  #else
-    #error Must define either _WIN32 or _UNIX
  #endif
 }
 
 // The "unlock" function release the critical section.
 sint32 CritSec::unlock(void) RO 
 {
- #ifdef _UNIX
+ #if !CRITSEC_PLATFORM_WINDOWS
     sint32	status = 0;
     
     assert(RefCount_ >= 0);
@@ -122,7 +120,7 @@ sint32 CritSec::unlock(void) RO
 	    ERRMSG("pthread_mutex_lock: " << strerror(errno));
     }
     return status;
- #elif defined(_WIN32)
+ #elif CRITSEC_PLATFORM_WINDOWS
     LeaveCriticalSection(&CritSec_);
     return(0);
  #endif

--- a/Generals/Code/Tools/matchbot/wlib/critsec.h
+++ b/Generals/Code/Tools/matchbot/wlib/critsec.h
@@ -20,12 +20,15 @@
 #define CRITSEC_HEADER
 
 #include "wstypes.h"
-#ifdef _WIN32
- #include <windows.h>
- #include <winbase.h>
-#elif defined(_UNIX)
-  #include <pthread.h>
-  #include <errno.h>
+
+#if defined(_WIN32) && !defined(__unix__) && !defined(__APPLE__)
+#define CRITSEC_PLATFORM_WINDOWS 1
+#include <windows.h>
+#include <winbase.h>
+#else
+#define CRITSEC_PLATFORM_WINDOWS 0
+#include <pthread.h>
+#include <errno.h>
 #endif
 
 // Windows headers have a tendency to redefine IN
@@ -50,7 +53,7 @@ class CritSec
   sint32		unlock(void) RO;
 
  protected:
-  #ifdef _WIN32
+  #if CRITSEC_PLATFORM_WINDOWS
     mutable CRITICAL_SECTION    CritSec_;
   #else
     mutable pthread_mutex_t	Mutex_;         // Mutex lock

--- a/Generals/Code/Tools/matchbot/wlib/dictionary.h
+++ b/Generals/Code/Tools/matchbot/wlib/dictionary.h
@@ -205,7 +205,33 @@ void Dictionary<K,V>::print(FILE *out) RO
 template <class K, class V>
 Dictionary<K,V> &Dictionary<K,V>::operator=(Dictionary<K,V> &other)
 {
-  _ASSERTE(0);
+  if (this == &other) {
+    return *this;
+  }
+
+  clear();
+  delete[] table;
+
+  size = other.size;
+  tableBits = other.tableBits;
+  log2Size = other.log2Size;
+  keepSize = other.keepSize;
+  entries = 0;
+  hashFunc = other.hashFunc;
+
+  table = new DNode<K,V>*[size];
+  assert(table != NULL);
+  memset(static_cast<void*>(table), 0, size * sizeof(DNode<K,V>*));
+
+  for (uint32 index = 0; index < other.size; ++index) {
+    DNode<K,V> *node = other.table[index];
+    while (node != NULL) {
+      add(node->key, node->value);
+      node = node->hashNext;
+    }
+  }
+
+  return *this;
 }
 
 

--- a/Generals/Code/Tools/matchbot/wlib/timezone.cpp
+++ b/Generals/Code/Tools/matchbot/wlib/timezone.cpp
@@ -16,43 +16,48 @@
 **	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "wlib/xtime.h"
+#include "xtime.h"
 #include "timezone.h"
 
 void GetTimezoneInfo(const char * &timezone_str, int &timezone_offset) {
-	timezone_str = "Unknown Timezone";
-	timezone_offset = 0;
-#ifdef _WINDOWS
-	struct _timeb    wintime;
-	_ftime(&wintime);
+        timezone_str = "Unknown Timezone";
+        timezone_offset = 0;
+#if defined(__unix__) || defined(__APPLE__) || defined(__linux__)
+        struct timeval   unixtime;
+        struct timezone  unixtzone;
+        gettimeofday(&unixtime,&unixtzone);
 
-	if (wintime.dstflag) {
-		// Daylight savings time
-		if (_daylight) {
-			timezone_str = _tzname[1];
-		}
-	} else {
-		timezone_str = _tzname[0];
-	}
-	timezone_offset = wintime.timezone * 60; // its in minutes...
+        struct tm unixtm;
+        localtime_r(&unixtime.tv_sec, &unixtm);
 
+        if (unixtm.tm_isdst > 0 && tzname[1] != nullptr) {
+                // Daylight savings time
+                timezone_str = tzname[1];
+        } else if (tzname[0] != nullptr) {
+                timezone_str = tzname[0];
+        }
+
+#if defined(__APPLE__) || (defined(__linux__) && defined(__GLIBC__))
+        timezone_offset = static_cast<int>(unixtm.tm_gmtoff);
+#else
+        timezone_offset = -unixtzone.tz_minuteswest * 60;
+        if (unixtm.tm_isdst > 0) {
+                timezone_offset += 3600;
+        }
 #endif
-#ifndef _WINDOWS
-	struct timeval   unixtime;
-	struct timezone  unixtzone;
-	gettimeofday(&unixtime,&unixtzone);
+#else
+        struct _timeb    wintime;
+        _ftime(&wintime);
 
-	struct tm unixtm;
-	localtime_r(&unixtime.tv_sec, &unixtm);
-
-	if (unixtm.tm_isdst) {
-		// Daylight savings time
-		if (daylight) timezone_str = tzname[1];
-		timezone_offset = altzone;
-	} else {
-		timezone_str = tzname[0];
-		timezone_offset = timezone;
-	}
+        if (wintime.dstflag) {
+                // Daylight savings time
+                if (_daylight) {
+                        timezone_str = _tzname[1];
+                }
+        } else {
+                timezone_str = _tzname[0];
+        }
+        timezone_offset = wintime.timezone * 60; // its in minutes...
 #endif
 }
 

--- a/Generals/Code/Tools/matchbot/wlib/wdebug.h
+++ b/Generals/Code/Tools/matchbot/wlib/wdebug.h
@@ -57,8 +57,11 @@ will you be ready to leave grasshopper.
 
 #include "wstypes.h"
 
-#ifdef _WINDOWS
+#if defined(_WIN32) && !defined(__unix__) && !defined(__APPLE__)
 #include <windows.h>
+#define WDEBUG_PLATFORM_WINDOWS 1
+#else
+#define WDEBUG_PLATFORM_WINDOWS 0
 #endif
 #include <iostream>
 #include <sstream>
@@ -186,7 +189,7 @@ extern CritSec DebugLibSemaphore;
 #define DBG(X) X
 
 // In Windows, send a copy to the debugger window
-#ifdef _WINDOWS
+#if WDEBUG_PLATFORM_WINDOWS
 
 // Print a variable
 #define PVAR(v) \
@@ -246,7 +249,7 @@ extern CritSec DebugLibSemaphore;
   DEBUGUNLOCK; \
 }
 
-#else // _WINDOWS
+#else // WDEBUG_PLATFORM_WINDOWS
 
 // Print a variable
 #define PVAR(v) \
@@ -286,7 +289,7 @@ extern CritSec DebugLibSemaphore;
      "]: " << ##X << std::endl; X \
   DEBUGUNLOCK; \
 }
-#endif // _WINDOWS
+#endif // WDEBUG_PLATFORM_WINDOWS
 
 #endif  // DEBUG
 

--- a/Generals/Code/Tools/matchbot/wlib/wstring.cpp
+++ b/Generals/Code/Tools/matchbot/wlib/wstring.cpp
@@ -34,6 +34,8 @@ string to it's own memory (for assignment or construction).
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
+#include <limits>
+#include <cstddef>
 
 #include "wstring.h"
 
@@ -375,7 +377,6 @@ bit8 Wstring::replace(IN char *replaceThis,IN char *withThis)
 {
   Wstring  dest;
   char    *foundStr, *src;
-  uint32   len;
 
   src=get();
   while(src && src[0])
@@ -383,9 +384,12 @@ bit8 Wstring::replace(IN char *replaceThis,IN char *withThis)
     foundStr = strstr(src, replaceThis);
     if(foundStr)
     {
-      len = (uint32)foundStr - (uint32)src;
-      if(len)
+      const ptrdiff_t diff = foundStr - src;
+      if(diff > 0)
       {
+        if(diff > static_cast<ptrdiff_t>(std::numeric_limits<uint32>::max()))
+          return(FALSE);
+        const uint32 len = static_cast<uint32>(diff);
         if(!dest.cat(len, src))
           return(FALSE);
       }

--- a/Generals/Code/Tools/matchbot/wlib/wtime.cpp
+++ b/Generals/Code/Tools/matchbot/wlib/wtime.cpp
@@ -35,7 +35,7 @@ static char *FULLMONTHS[]={"January","February","March","April","May","June",
                "July","August","September","October","November","December"};
 
 // MDC: Windows doesn't provide a localtime_r, so make our own...
-#ifdef _WINDOWS
+#if defined(_WIN32) && !defined(__unix__) && !defined(__APPLE__)
 #ifdef _REENTRANT
 #include "critsec.h"
 static CritSec localtime_critsec;
@@ -54,7 +54,7 @@ static struct tm *localtime_r(const time_t *clockval, struct tm *res) {
 #endif
 	return res;
 }
-#endif // _WINDOWS
+#endif // platform-specific localtime_r
 
 Wtime::Wtime(void)
 {
@@ -82,19 +82,18 @@ Wtime::~Wtime()
 void Wtime::Update(void)
 {
  sign=POSITIVE;
- #ifdef _WINDOWS
-  struct _timeb    wintime;
-  _ftime(&wintime);
-  sec=wintime.time;
-  usec=(wintime.millitm)*1000;
- #endif
- #ifndef _WINDOWS
+#if defined(__unix__) || defined(__APPLE__) || defined(__linux__)
   struct timeval   unixtime;
   struct timezone  unixtzone;
   gettimeofday(&unixtime,&unixtzone);
   sec=unixtime.tv_sec;
   usec=unixtime.tv_usec;
- #endif
+#else
+  struct _timeb    wintime;
+  _ftime(&wintime);
+  sec=wintime.time;
+  usec=(wintime.millitm)*1000;
+#endif
 }
 
 

--- a/Generals/Code/Tools/matchbot/wlib/wtime.h
+++ b/Generals/Code/Tools/matchbot/wlib/wtime.h
@@ -29,7 +29,7 @@ wtime                      Neal Kettler
 #include <assert.h>
 #include <sys/types.h>
 
-#ifndef _WINDOWS
+#if defined(__unix__) || defined(__APPLE__) || defined(__linux__)
 #include <unistd.h>
 #include <netinet/in.h>
 #include <sys/time.h>

--- a/Generals/Code/Tools/matchbot/wlib/xtime.cpp
+++ b/Generals/Code/Tools/matchbot/wlib/xtime.cpp
@@ -29,7 +29,7 @@ long long after you'll be dead.
 
 #include <ctype.h>
 #include <time.h>
-#ifndef _WINDOWS
+#if defined(__unix__) || defined(__APPLE__) || defined(__linux__)
 #include <sys/time.h>
 #endif
 #include "xtime.h"
@@ -286,19 +286,18 @@ void Xtime::update(void)
   day_=719528;  // day_s from year 0 to Jan1, 1970
   msec_=0;
 
- #ifdef _WINDOWS
-  struct _timeb    wintime;
-  _ftime(&wintime);
-  addSeconds(wintime.time);
-  msec_+=wintime.millitm;
- #endif
- #ifndef _WINDOWS
+#if defined(__unix__) || defined(__APPLE__) || defined(__linux__)
   struct timeval   unixtime;
   struct timezone  unixtzone;
   gettimeofday(&unixtime,&unixtzone);
   addSeconds(unixtime.tv_sec);
   msec_+=(unixtime.tv_usec/1000);
- #endif
+#else
+  struct _timeb    wintime;
+  _ftime(&wintime);
+  addSeconds(wintime.time);
+  msec_+=wintime.millitm;
+#endif
 
   // Now normalize in case msec is > 1 days worth
   normalize();

--- a/Generals/Code/Tools/matchbot/wlib/xtime.h
+++ b/Generals/Code/Tools/matchbot/wlib/xtime.h
@@ -38,7 +38,7 @@ function :-)
 #include <assert.h>
 #include <sys/types.h>
 
-#ifndef _WINDOWS
+#if defined(__unix__) || defined(__APPLE__) || defined(__linux__)
 #include <unistd.h>
 #include <netinet/in.h>
 #include <sys/time.h>

--- a/Generals/Code/Tools/matchbot/wnet/field.cpp
+++ b/Generals/Code/Tools/matchbot/wnet/field.cpp
@@ -34,7 +34,7 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 #include <string.h>
 #include <sys/types.h>
-#ifndef _WINDOWS
+#if defined(__unix__) || defined(__APPLE__) || defined(__linux__)
 #include <netinet/in.h>
 #else
 #define Win32_Winsock

--- a/Generals/Code/Tools/matchbot/wnet/packet.cpp
+++ b/Generals/Code/Tools/matchbot/wnet/packet.cpp
@@ -39,7 +39,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
-#ifndef _WINDOWS
+#if defined(__unix__) || defined(__APPLE__) || defined(__linux__)
 #include <netinet/in.h>
 #else
 #define Win32_Winsock

--- a/Generals/Code/Tools/matchbot/wnet/packet.h
+++ b/Generals/Code/Tools/matchbot/wnet/packet.h
@@ -40,7 +40,7 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #include "field.h"
-#include <wlib/wstypes.h>
+#include "../wlib/wstypes.h"
 
 
 class PacketClass

--- a/Generals/Code/Tools/matchbot/wnet/tcp.cpp
+++ b/Generals/Code/Tools/matchbot/wnet/tcp.cpp
@@ -45,7 +45,7 @@ TCP tcp(CLIENT);
 
 tcp.Bind((uint32)0,(uint16)0); // let system pick local IP and a Port for you 
 tcp.Connect("tango",13);       // can connect by name or "10.1.1.10"
-                               // or the integerﬂin host byte order
+                               // or the integer√üin host byte order
 
 fdSet=tcp.Wait(10,0);          // wait for UP TO 10 sec and 0 microseconds
 if (FD_ISSET(tcp.GetFD(),fdSet))   // Is there something to read?
@@ -99,7 +99,7 @@ while (1)
 #include "tcp.h"
 #include <stdarg.h>
 
-#ifndef _WINDOWS
+#if !TCP_PLATFORM_WINDOWS
 #include <errno.h>
 #define closesocket close
 #endif
@@ -170,7 +170,7 @@ sint32 TCP::SetBlocking(bit8 block,sint32 whichFD)
    if (whichFD==0)
      whichFD=fd;
 
-   #ifdef _WINDOWS
+   #if TCP_PLATFORM_WINDOWS
    unsigned long flag=1;
    if (block)
      flag=0;
@@ -219,7 +219,7 @@ sint32 TCP::Write(const uint8 *msg,uint32 len,sint32 whichFD)
   }
   SetBlocking(TRUE,whichFD); 
   retval=send(whichFD,(const char *)msg,len,0);
-  #ifdef _WINDOWS
+  #if TCP_PLATFORM_WINDOWS
     if (retval==SOCKET_ERROR)
       retval=-1;
   #endif
@@ -241,7 +241,7 @@ sint32 TCP::WriteNB(uint8 *msg,uint32 len,sint32 whichFD)
     whichFD=fd;
   }
   retval=send(whichFD,(const char *)msg,len,0);
-  #ifdef _WINDOWS
+  #if TCP_PLATFORM_WINDOWS
     if (retval==SOCKET_ERROR)
       retval=-1;
   #endif
@@ -378,7 +378,7 @@ sint32 TCP::Printf(sint32 whichFD,const char *format,...)
 uint32 TCP::GetRemoteIP(sint32 whichFD)
 {
   struct sockaddr_in sin;
-  int    sinSize=sizeof(sin);
+  socklen_t    sinSize=sizeof(sin);
 
   if (mode==CLIENT)
   {
@@ -399,7 +399,7 @@ uint32 TCP::GetRemoteIP(sint32 whichFD)
 uint16 TCP::GetRemotePort(sint32 whichFD)
 {
   struct sockaddr_in sin;
-  int    sinSize=sizeof(sin);
+  socklen_t    sinSize=sizeof(sin);
 
   if (mode==CLIENT)
   {
@@ -419,7 +419,7 @@ uint16 TCP::GetRemotePort(sint32 whichFD)
 bit8 TCP::IsConnected(sint32 whichFD)
 {
   struct sockaddr_in sin;
-  int    sinSize=sizeof(sin);
+  socklen_t    sinSize=sizeof(sin);
 
   if (mode==CLIENT)
     whichFD=fd;
@@ -942,7 +942,7 @@ bit8 TCP::Bind(uint32 IP,uint16 Port,bit8 reuseAddr)
   }
 
   retval=bind(fd,(struct sockaddr *)&addr,sizeof(addr));
-  #ifdef _WINDOWS
+  #if TCP_PLATFORM_WINDOWS
     if (retval==SOCKET_ERROR)
       retval=-1;
   #endif
@@ -1013,7 +1013,7 @@ bit8 TCP::Connect(uint32 IP,uint16 Port)
     result = connect(fd,(struct sockaddr *)&serverAddr, sizeof(serverAddr));
     status=GetStatus();
 
-    #ifdef _WINDOWS
+    #if TCP_PLATFORM_WINDOWS
       if (result==SOCKET_ERROR)
         result=-1;
     #endif
@@ -1033,7 +1033,7 @@ bit8 TCP::Connect(uint32 IP,uint16 Port)
       tries++;
       sleep_time.tv_sec = 0;
       sleep_time.tv_usec = (100000*(tries+1));
-      #ifdef WIN32
+      #if TCP_PLATFORM_WINDOWS
         Sleep((sleep_time.tv_usec)/1000);
       #else
         select(0, 0, 0, 0, &sleep_time);
@@ -1107,7 +1107,7 @@ bit8 TCP::ConnectAsync(uint32 IP,uint16 Port)
   connectErrno=errno;
   status=GetStatus();
 
-  #ifdef _WINDOWS
+  #if TCP_PLATFORM_WINDOWS
     if (result==SOCKET_ERROR)
     {
       DBGMSG("Socket error 1  " << status);
@@ -1124,7 +1124,7 @@ bit8 TCP::ConnectAsync(uint32 IP,uint16 Port)
     ClearStatus();
     result = connect(fd,(struct sockaddr *)&serverAddr, sizeof(serverAddr));
     status=GetStatus();
-    #ifdef _WINDOWS
+    #if TCP_PLATFORM_WINDOWS
       if (result==SOCKET_ERROR)
       {
         DBGMSG("Socket error 2  " << status);
@@ -1159,14 +1159,14 @@ bit8 TCP::ConnectAsync(uint32 IP,uint16 Port)
 
 void TCP::ClearStatus(void)
 {
-  #ifndef _WINDOWS
+  #if !TCP_PLATFORM_WINDOWS
   errno=0;
   #endif
 }
 
 int TCP::GetStatus(void)
 {
-  #ifdef _WINDOWS
+  #if TCP_PLATFORM_WINDOWS
   int status=WSAGetLastError();
   if (status==0) return(OK);
   else if (status==WSAEINTR) return(INTR);
@@ -1208,7 +1208,7 @@ sint32 TCP::GetConnection(void)
 
   sint32 clientFD;
   struct sockaddr_in clientAddr;
-  int addrlen=sizeof(clientAddr);
+  socklen_t addrlen=sizeof(clientAddr);
 
   clientFD=accept(fd,(struct sockaddr *)&clientAddr,&addrlen);
   if (clientFD!=-1)
@@ -1227,7 +1227,7 @@ sint32 TCP::GetConnection(struct sockaddr *clientAddr)
     return(-1);
 
   sint32 clientFD;
-  int addrlen=sizeof(struct sockaddr);
+  socklen_t addrlen=sizeof(struct sockaddr);
 
   clientFD=accept(fd,(struct sockaddr *)clientAddr,&addrlen);
   if (clientFD!=-1)

--- a/Generals/Code/Tools/matchbot/wnet/tcp.h
+++ b/Generals/Code/Tools/matchbot/wnet/tcp.h
@@ -31,15 +31,17 @@ TCP                   Neal Kettler        neal@westwood.com
 #include <string.h>
 #include <assert.h>
 
-#ifdef _WINDOWS
+#if defined(_WIN32) && !defined(__unix__) && !defined(__APPLE__)
+#define TCP_PLATFORM_WINDOWS 1
 
-#include <winsock.h>
+#include <winsock2.h>
 #include <io.h>
 #define close _close
 #define read  _read
 #define write _write
 
-#else  //UNIX
+#else  // POSIX
+#define TCP_PLATFORM_WINDOWS 0
 #include <netdb.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -61,9 +63,9 @@ typedef signed int SOCKET;
 
 #define DEFAULT_PROTOCOL 0
 
-#include "wlib/wstypes.h"
-#include "wlib/wdebug.h"
-#include "wlib/wtime.h"
+#include "../wlib/wstypes.h"
+#include "../wlib/wdebug.h"
+#include "../wlib/wtime.h"
 
 class TCP
 {

--- a/Generals/Code/Tools/matchbot/wnet/udp.h
+++ b/Generals/Code/Tools/matchbot/wnet/udp.h
@@ -25,14 +25,16 @@
 #include <errno.h>
 #include <string.h>
 
-#ifdef _WINDOWS
-#include <winsock.h>
+#if defined(_WIN32) && !defined(__unix__) && !defined(__APPLE__)
+#define UDP_PLATFORM_WINDOWS 1
+#include <winsock2.h>
 #include <io.h>
 #define close _close
 #define read  _read
 #define write _write
 
-#else  //UNIX
+#else  // POSIX
+#define UDP_PLATFORM_WINDOWS 0
 #include <netdb.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -50,8 +52,8 @@
 
 #define DEFAULT_PROTOCOL 0
 
-#include <wlib/wstypes.h>
-#include <wlib/wtime.h>
+#include "../wlib/wstypes.h"
+#include "../wlib/wtime.h"
 
 class UDP
 {


### PR DESCRIPTION
## Summary
- Replace Windows-only includes in matchbot sources with POSIX-safe guard logic and add Linux-friendly runtime helpers.
- Update wlib/wnet utilities to use portable types and includes for sockets, time, and synchronization.
- Introduce a lightweight GameSpy peer stub with message type definitions and a `peerMessagePlayer` no-op to unblock the build.

## Testing
- g++ -std=c++17 -I Generals/Code/Tools/matchbot -c Generals/Code/Tools/matchbot/peer/peer.cpp -o /tmp/peer.o
- g++ -std=c++17 -I Generals/Code/Tools/matchbot -c Generals/Code/Tools/matchbot/generals.cpp -o /tmp/generals.o

------
https://chatgpt.com/codex/tasks/task_e_68ceff7846488331b21e6299900f37ac