### PR TITLE
Add cross-platform WPAudio infrastructure headers

### DIFF
--- a/Generals/Code/GameEngine/Include/wpaudio/StreamBuffering.h
+++ b/Generals/Code/GameEngine/Include/wpaudio/StreamBuffering.h
@@ -1,0 +1,142 @@
+#pragma once
+
+#include "wpaudio/altypes.h"
+#include "wpaudio/list.h"
+#include "wpaudio/lock.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+struct File;
+
+constexpr int vSTM_MAX_ACCESSORS = 2;
+constexpr int vSTM_ACCESS_ID_IN = 0;
+constexpr int vSTM_ACCESS_ID_OUT = 1;
+
+constexpr int vSTM_ACCESS_MODE_UPDATE = 0;
+constexpr int vSTM_ACCESS_MAX_MODES = 1;
+
+constexpr UnsignedInt mSTM_STREAM_FAKE = 1u << 0;
+constexpr UnsignedInt mSTM_STREAM_RESET_DONE = 1u << 1;
+constexpr UnsignedInt mSTM_ACCESS_TOP_OF_START = 1u << 0;
+constexpr UnsignedInt mSTM_PROFILE_ACTIVE = 1u << 0;
+
+constexpr UnsignedInt W_UINT_MAX = std::numeric_limits<UnsignedInt>::max();
+
+inline std::size_t AlignUpBy(std::size_t value, std::size_t alignment)
+{
+    if (alignment == 0)
+    {
+        return value;
+    }
+    const std::size_t mask = alignment - 1;
+    return (value + mask) & ~mask;
+}
+
+#define ALIGN_UPBY(value, alignment) AlignUpBy(static_cast<std::size_t>(value), static_cast<std::size_t>(alignment))
+
+inline void W_FlagsSet(UnsignedInt& flags, UnsignedInt mask)
+{
+    flags |= mask;
+}
+
+inline void W_FlagsClear(UnsignedInt& flags, UnsignedInt mask)
+{
+    flags &= ~mask;
+}
+
+struct STM_STREAM;
+struct STM_SBUFFER;
+struct STM_ACCESS;
+struct STM_PROFILE;
+
+struct STM_REGION
+{
+    UnsignedByte* Data = nullptr;
+    UnsignedInt Bytes = 0;
+};
+
+struct STM_SBUFFER
+{
+    ListNode nd{};
+    STM_STREAM* stream = nullptr;
+    UnsignedByte* buffer_memory = nullptr;
+    STM_REGION data_region{};
+    STM_REGION region[vSTM_MAX_ACCESSORS]{};
+};
+
+struct STM_ACCESS
+{
+    STM_STREAM* stream = nullptr;
+    STM_SBUFFER* SBuffer = nullptr;
+    STM_SBUFFER* start_buffer = nullptr;
+    STM_REGION Block{};
+    Lock in_service{};
+    Lock ref{};
+    UnsignedInt bytes_in = 0;
+    UnsignedInt bytes_out = 0;
+    UnsignedInt flags = 0;
+    int mode = vSTM_ACCESS_MODE_UPDATE;
+    int id = 0;
+    UnsignedInt access_pos = 0;
+    UnsignedInt position = 0;
+    int last_error = 0;
+};
+
+struct STM_STREAM
+{
+    ListHead buffer_list{};
+    Lock ref{};
+    STM_ACCESS access[vSTM_MAX_ACCESSORS]{};
+    int buffers = 0;
+    UnsignedInt bytes = 0;
+    UnsignedInt flags = 0;
+};
+
+struct STM_PROFILE
+{
+    UnsignedInt bytes = 0;
+    UnsignedInt rate = 0;
+    UnsignedInt update_interval = 0;
+    TimeStamp last_update = 0;
+    UnsignedInt flags = 0;
+};
+
+void STM_stream_reset(STM_STREAM* stm);
+STM_STREAM* STM_StreamCreate(void);
+void STM_StreamDestroy(STM_STREAM* stm);
+void STM_StreamDestroyBuffers(STM_STREAM* stm);
+void STM_StreamReset(STM_STREAM* stm);
+void STM_StreamAddSBuffer(STM_STREAM* stm, STM_SBUFFER* sbuf);
+int STM_StreamCreateSBuffers(STM_STREAM* stm, int numBuffers, int bufferSize, int align);
+STM_ACCESS* STM_StreamAcquireAccess(STM_STREAM* stm, int accessId);
+UnsignedInt STM_StreamTotalBytesIn(STM_STREAM* stm);
+UnsignedInt STM_StreamTotalBytesTillFull(STM_STREAM* stm);
+UnsignedInt STM_StreamTotalBytes(STM_STREAM* stm);
+int STM_StreamFull(STM_STREAM* stm);
+STM_SBUFFER* STM_SBufferCreate(int bytes, int align);
+void STM_SBufferDestroy(STM_SBUFFER* sbuf);
+void STM_SBufferRemove(STM_SBUFFER* sbuf);
+STM_SBUFFER* STM_SBufferNext(STM_SBUFFER* sbuf);
+void STM_AccessRelease(STM_ACCESS* access);
+int STM_AccessSetMode(STM_ACCESS* access, int mode);
+int STM_AccessMode(STM_ACCESS* access);
+int STM_AccessID(STM_ACCESS* access);
+int STM_AccessTransfer(STM_ACCESS* access, void* data, int bytes);
+int STM_AccessFileTransfer(STM_ACCESS* access, File* file, int bytes, int* transferred);
+int STM_AccessGetError(STM_ACCESS* access);
+int STM_AccessUpdate(STM_ACCESS* access);
+int STM_AccessAdvance(STM_ACCESS* access, int bytesToAdvance);
+void STM_AccessReturnToStart(STM_ACCESS* access);
+int STM_AccessNextBlock(STM_ACCESS* access);
+int STM_AccessGetBlock(STM_ACCESS* access);
+UnsignedInt STM_AccessTotalBytes(STM_ACCESS* access);
+UnsignedInt STM_AccessPosition(STM_ACCESS* access);
+STM_ACCESS* STM_AccessUpStreamAccessor(STM_ACCESS* access);
+void STM_ProfileStart(STM_PROFILE* pf);
+void STM_ProfileStop(STM_PROFILE* pf);
+void STM_ProfileUpdate(STM_PROFILE* pf, int bytes);
+int STM_ProfileResult(STM_PROFILE* pf);
+int STM_ProfileActive(STM_PROFILE* pf);
+

--- a/Generals/Code/GameEngine/Include/wpaudio/altypes.h
+++ b/Generals/Code/GameEngine/Include/wpaudio/altypes.h
@@ -2,6 +2,7 @@
 
 #include "always.h"
 #include "Lib/BaseType.h"
+#include "wpaudio/debug.h"
 
 #include <algorithm>
 #include <chrono>
@@ -16,8 +17,16 @@ inline TimeStamp MSECONDS(Int value) {
     return static_cast<TimeStamp>(value);
 }
 
+inline TimeStamp SECONDS(Int value) {
+    return static_cast<TimeStamp>(static_cast<int64_t>(value) * 1000);
+}
+
 inline Int IN_MSECONDS(TimeStamp value) {
     return static_cast<Int>(value);
+}
+
+inline Int IN_SECONDS(TimeStamp value) {
+    return static_cast<Int>(value / 1000);
 }
 
 inline TimeStamp AudioGetTime() {

--- a/Generals/Code/GameEngine/Include/wpaudio/debug.h
+++ b/Generals/Code/GameEngine/Include/wpaudio/debug.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cassert>
+#include <cstdio>
+
+#if defined(NDEBUG)
+#define DBG_CODE(expr) do { (void)sizeof(expr); } while (false)
+#else
+#define DBG_CODE(expr) do { expr; } while (false)
+#endif
+
+#define DBG_DECLARE_TYPE(Type)
+#define DBG_TYPE()
+#define DBG_SET_TYPE(ptr, Type) do { (void)(ptr); } while (false)
+#define DBG_INVALIDATE_TYPE(ptr) do { (void)(ptr); } while (false)
+
+#define DBG_ASSERT(expr) assert((expr))
+#define DBG_ASSERT_PTR(ptr) assert((ptr) != nullptr)
+#define DBG_ASSERT_TYPE(ptr, Type) assert((ptr) != nullptr)
+
+#define DBG_MSGASSERT(expr, args)                                                    \
+    do {                                                                             \
+        if (!(expr)) {                                                               \
+            std::printf args;                                                        \
+            assert((expr));                                                          \
+        }                                                                            \
+    } while (false)
+
+#define DBGPRINTF(args) do { std::printf args; } while (false)
+#define DBG_Function(name) do { (void)(name); } while (false)
+
+#define DBG_ASSERT_MSG(expr, args)                                                   \
+    do {                                                                             \
+        if (!(expr)) {                                                               \
+            std::printf args;                                                        \
+            assert((expr));                                                          \
+        }                                                                            \
+    } while (false)
+

--- a/Generals/Code/GameEngine/Include/wpaudio/list.h
+++ b/Generals/Code/GameEngine/Include/wpaudio/list.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "wpaudio/altypes.h"
+
+#include <cstdint>
+
+using Priority = std::intptr_t;
+
+struct ListNode
+{
+    ListNode* prev = nullptr;
+    ListNode* next = nullptr;
+    Priority pri = 0;
+};
+
+using ListHead = ListNode;
+
+inline bool ListNodeIsHead(const ListNode* node)
+{
+    return node != nullptr && node->pri == reinterpret_cast<Priority>(node);
+}
+
+inline bool ListNodeInList(const ListNode* node)
+{
+    return node != nullptr && (node->next != node || node->prev != node);
+}
+
+void ListInit(ListHead* head);
+void ListNodeInit(ListNode* node);
+int ListAddNodeSortAscending(ListHead* head, ListNode* newNode);
+void ListAddNode(ListHead* head, ListNode* newNode);
+void ListAddNodeAfter(ListHead* head, ListNode* newNode);
+void ListMerge(ListHead* from, ListHead* to);
+int ListCountItems(ListHead* head);
+ListNode* ListFirstItem(ListHead* head);
+ListNode* ListNextItem(ListNode* node);
+ListNode* ListGetItem(ListHead* head, int number);
+void ListNodeInsert(ListNode* node, ListNode* newNode);
+void ListNodeAppend(ListNode* node, ListNode* newNode);
+void ListNodeRemove(ListNode* node);
+ListNode* ListNodeNext(ListNode* node);
+ListNode* ListNodePrev(ListNode* node);
+ListNode* ListNodeLoopNext(ListNode* node);
+ListNode* ListNodeLoopPrev(ListNode* node);
+
+inline void ListAddToTail(ListHead* head, ListNode* node)
+{
+    if (head != nullptr && node != nullptr)
+    {
+        ListNodeInsert(reinterpret_cast<ListNode*>(head), node);
+    }
+}
+

--- a/Generals/Code/GameEngine/Include/wpaudio/lock.h
+++ b/Generals/Code/GameEngine/Include/wpaudio/lock.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "wpaudio/altypes.h"
+
+#include <atomic>
+#include <mutex>
+
+struct Lock
+{
+    std::recursive_mutex mutex;
+    std::atomic<int> count{0};
+};
+
+inline void LockInitPrimitive(Lock* lock)
+{
+    if (lock != nullptr)
+    {
+        lock->count.store(0, std::memory_order_relaxed);
+    }
+}
+
+inline void LockAcquirePrimitive(Lock* lock)
+{
+    if (lock != nullptr)
+    {
+        lock->mutex.lock();
+        lock->count.fetch_add(1, std::memory_order_relaxed);
+    }
+}
+
+inline void LockReleasePrimitive(Lock* lock)
+{
+    if (lock != nullptr)
+    {
+        lock->count.fetch_sub(1, std::memory_order_relaxed);
+        lock->mutex.unlock();
+    }
+}
+
+inline bool LockIsLockedPrimitive(const Lock* lock)
+{
+    return lock != nullptr && lock->count.load(std::memory_order_relaxed) > 0;
+}
+
+#define LOCK_INIT(lockPtr) LockInitPrimitive(const_cast<Lock*>(lockPtr))
+#define LOCK_ACQUIRE(lockPtr) LockAcquirePrimitive(const_cast<Lock*>(lockPtr))
+#define LOCK_RELEASE(lockPtr) LockReleasePrimitive(const_cast<Lock*>(lockPtr))
+#define LOCKED(lockPtr) LockIsLockedPrimitive(lockPtr)
+#define NotLocked(lockPtr) (!LockIsLockedPrimitive(lockPtr))
+

--- a/Generals/Code/GameEngine/Include/wpaudio/memory.h
+++ b/Generals/Code/GameEngine/Include/wpaudio/memory.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "wpaudio/altypes.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+
+struct MemoryItem
+{
+    MemoryItem* next = nullptr;
+};
+
+struct AudioMemoryPool
+{
+    MemoryItem* next = nullptr;
+    std::size_t itemSize = 0;
+    std::size_t itemCount = 0;
+    std::size_t itemsOut = 0;
+};
+
+inline void* AudioMemAlloc(std::size_t size)
+{
+    return std::malloc(size);
+}
+
+inline void* AudioMemAllocZero(std::size_t size)
+{
+    void* ptr = std::calloc(1u, size);
+    return ptr;
+}
+
+inline void AudioMemFree(void* ptr)
+{
+    std::free(ptr);
+}
+
+inline void AudioMemCopy(void* dst, const void* src, std::size_t size)
+{
+    if (dst != nullptr && src != nullptr)
+    {
+        std::memcpy(dst, src, size);
+    }
+}
+
+inline void AudioMemSet(void* dst, int value, std::size_t size)
+{
+    if (dst != nullptr)
+    {
+        std::memset(dst, value, size);
+    }
+}
+
+template <typename T>
+inline T* AudioMemAllocStruct()
+{
+    return reinterpret_cast<T*>(AudioMemAllocZero(sizeof(T)));
+}
+
+#define ALLOC_STRUCT(var, Type) Type* var = AudioMemAllocStruct<Type>()
+#define MEM_ALLOC_STRUCT(var, Type, flags) ALLOC_STRUCT(var, Type)
+#define MEM_Free(ptr) AudioMemFree(ptr)
+
+AudioMemoryPool* MemoryPoolCreate(std::size_t items, std::size_t size);
+void MemoryPoolDestroy(AudioMemoryPool* pool);
+void* MemoryPoolGetItem(AudioMemoryPool* pool);
+void MemoryPoolReturnItem(AudioMemoryPool* pool, void* data);
+int MemoryPoolCount(AudioMemoryPool* pool);
+
+void AudioAddSlash(char* string);
+int AudioHasPath(const char* string);
+

--- a/Generals/Code/GameEngine/Include/wpaudio/time.h
+++ b/Generals/Code/GameEngine/Include/wpaudio/time.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#include "wpaudio/Time.h"
+

--- a/GeneralsMD/Code/GameEngine/Include/wpaudio/StreamBuffering.h
+++ b/GeneralsMD/Code/GameEngine/Include/wpaudio/StreamBuffering.h
@@ -1,0 +1,142 @@
+#pragma once
+
+#include "wpaudio/altypes.h"
+#include "wpaudio/list.h"
+#include "wpaudio/lock.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+struct File;
+
+constexpr int vSTM_MAX_ACCESSORS = 2;
+constexpr int vSTM_ACCESS_ID_IN = 0;
+constexpr int vSTM_ACCESS_ID_OUT = 1;
+
+constexpr int vSTM_ACCESS_MODE_UPDATE = 0;
+constexpr int vSTM_ACCESS_MAX_MODES = 1;
+
+constexpr UnsignedInt mSTM_STREAM_FAKE = 1u << 0;
+constexpr UnsignedInt mSTM_STREAM_RESET_DONE = 1u << 1;
+constexpr UnsignedInt mSTM_ACCESS_TOP_OF_START = 1u << 0;
+constexpr UnsignedInt mSTM_PROFILE_ACTIVE = 1u << 0;
+
+constexpr UnsignedInt W_UINT_MAX = std::numeric_limits<UnsignedInt>::max();
+
+inline std::size_t AlignUpBy(std::size_t value, std::size_t alignment)
+{
+    if (alignment == 0)
+    {
+        return value;
+    }
+    const std::size_t mask = alignment - 1;
+    return (value + mask) & ~mask;
+}
+
+#define ALIGN_UPBY(value, alignment) AlignUpBy(static_cast<std::size_t>(value), static_cast<std::size_t>(alignment))
+
+inline void W_FlagsSet(UnsignedInt& flags, UnsignedInt mask)
+{
+    flags |= mask;
+}
+
+inline void W_FlagsClear(UnsignedInt& flags, UnsignedInt mask)
+{
+    flags &= ~mask;
+}
+
+struct STM_STREAM;
+struct STM_SBUFFER;
+struct STM_ACCESS;
+struct STM_PROFILE;
+
+struct STM_REGION
+{
+    UnsignedByte* Data = nullptr;
+    UnsignedInt Bytes = 0;
+};
+
+struct STM_SBUFFER
+{
+    ListNode nd{};
+    STM_STREAM* stream = nullptr;
+    UnsignedByte* buffer_memory = nullptr;
+    STM_REGION data_region{};
+    STM_REGION region[vSTM_MAX_ACCESSORS]{};
+};
+
+struct STM_ACCESS
+{
+    STM_STREAM* stream = nullptr;
+    STM_SBUFFER* SBuffer = nullptr;
+    STM_SBUFFER* start_buffer = nullptr;
+    STM_REGION Block{};
+    Lock in_service{};
+    Lock ref{};
+    UnsignedInt bytes_in = 0;
+    UnsignedInt bytes_out = 0;
+    UnsignedInt flags = 0;
+    int mode = vSTM_ACCESS_MODE_UPDATE;
+    int id = 0;
+    UnsignedInt access_pos = 0;
+    UnsignedInt position = 0;
+    int last_error = 0;
+};
+
+struct STM_STREAM
+{
+    ListHead buffer_list{};
+    Lock ref{};
+    STM_ACCESS access[vSTM_MAX_ACCESSORS]{};
+    int buffers = 0;
+    UnsignedInt bytes = 0;
+    UnsignedInt flags = 0;
+};
+
+struct STM_PROFILE
+{
+    UnsignedInt bytes = 0;
+    UnsignedInt rate = 0;
+    UnsignedInt update_interval = 0;
+    TimeStamp last_update = 0;
+    UnsignedInt flags = 0;
+};
+
+void STM_stream_reset(STM_STREAM* stm);
+STM_STREAM* STM_StreamCreate(void);
+void STM_StreamDestroy(STM_STREAM* stm);
+void STM_StreamDestroyBuffers(STM_STREAM* stm);
+void STM_StreamReset(STM_STREAM* stm);
+void STM_StreamAddSBuffer(STM_STREAM* stm, STM_SBUFFER* sbuf);
+int STM_StreamCreateSBuffers(STM_STREAM* stm, int numBuffers, int bufferSize, int align);
+STM_ACCESS* STM_StreamAcquireAccess(STM_STREAM* stm, int accessId);
+UnsignedInt STM_StreamTotalBytesIn(STM_STREAM* stm);
+UnsignedInt STM_StreamTotalBytesTillFull(STM_STREAM* stm);
+UnsignedInt STM_StreamTotalBytes(STM_STREAM* stm);
+int STM_StreamFull(STM_STREAM* stm);
+STM_SBUFFER* STM_SBufferCreate(int bytes, int align);
+void STM_SBufferDestroy(STM_SBUFFER* sbuf);
+void STM_SBufferRemove(STM_SBUFFER* sbuf);
+STM_SBUFFER* STM_SBufferNext(STM_SBUFFER* sbuf);
+void STM_AccessRelease(STM_ACCESS* access);
+int STM_AccessSetMode(STM_ACCESS* access, int mode);
+int STM_AccessMode(STM_ACCESS* access);
+int STM_AccessID(STM_ACCESS* access);
+int STM_AccessTransfer(STM_ACCESS* access, void* data, int bytes);
+int STM_AccessFileTransfer(STM_ACCESS* access, File* file, int bytes, int* transferred);
+int STM_AccessGetError(STM_ACCESS* access);
+int STM_AccessUpdate(STM_ACCESS* access);
+int STM_AccessAdvance(STM_ACCESS* access, int bytesToAdvance);
+void STM_AccessReturnToStart(STM_ACCESS* access);
+int STM_AccessNextBlock(STM_ACCESS* access);
+int STM_AccessGetBlock(STM_ACCESS* access);
+UnsignedInt STM_AccessTotalBytes(STM_ACCESS* access);
+UnsignedInt STM_AccessPosition(STM_ACCESS* access);
+STM_ACCESS* STM_AccessUpStreamAccessor(STM_ACCESS* access);
+void STM_ProfileStart(STM_PROFILE* pf);
+void STM_ProfileStop(STM_PROFILE* pf);
+void STM_ProfileUpdate(STM_PROFILE* pf, int bytes);
+int STM_ProfileResult(STM_PROFILE* pf);
+int STM_ProfileActive(STM_PROFILE* pf);
+

--- a/GeneralsMD/Code/GameEngine/Include/wpaudio/altypes.h
+++ b/GeneralsMD/Code/GameEngine/Include/wpaudio/altypes.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "always.h"
+#include "Lib/BaseType.h"
+#include "wpaudio/debug.h"
 
 #include <algorithm>
 #include <chrono>
@@ -15,8 +17,16 @@ inline TimeStamp MSECONDS(Int value) {
     return static_cast<TimeStamp>(value);
 }
 
+inline TimeStamp SECONDS(Int value) {
+    return static_cast<TimeStamp>(static_cast<int64_t>(value) * 1000);
+}
+
 inline Int IN_MSECONDS(TimeStamp value) {
     return static_cast<Int>(value);
+}
+
+inline Int IN_SECONDS(TimeStamp value) {
+    return static_cast<Int>(value / 1000);
 }
 
 inline TimeStamp AudioGetTime() {

--- a/GeneralsMD/Code/GameEngine/Include/wpaudio/debug.h
+++ b/GeneralsMD/Code/GameEngine/Include/wpaudio/debug.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cassert>
+#include <cstdio>
+
+#if defined(NDEBUG)
+#define DBG_CODE(expr) do { (void)sizeof(expr); } while (false)
+#else
+#define DBG_CODE(expr) do { expr; } while (false)
+#endif
+
+#define DBG_DECLARE_TYPE(Type)
+#define DBG_TYPE()
+#define DBG_SET_TYPE(ptr, Type) do { (void)(ptr); } while (false)
+#define DBG_INVALIDATE_TYPE(ptr) do { (void)(ptr); } while (false)
+
+#define DBG_ASSERT(expr) assert((expr))
+#define DBG_ASSERT_PTR(ptr) assert((ptr) != nullptr)
+#define DBG_ASSERT_TYPE(ptr, Type) assert((ptr) != nullptr)
+
+#define DBG_MSGASSERT(expr, args)                                                    \
+    do {                                                                             \
+        if (!(expr)) {                                                               \
+            std::printf args;                                                        \
+            assert((expr));                                                          \
+        }                                                                            \
+    } while (false)
+
+#define DBGPRINTF(args) do { std::printf args; } while (false)
+#define DBG_Function(name) do { (void)(name); } while (false)
+
+#define DBG_ASSERT_MSG(expr, args)                                                   \
+    do {                                                                             \
+        if (!(expr)) {                                                               \
+            std::printf args;                                                        \
+            assert((expr));                                                          \
+        }                                                                            \
+    } while (false)
+

--- a/GeneralsMD/Code/GameEngine/Include/wpaudio/list.h
+++ b/GeneralsMD/Code/GameEngine/Include/wpaudio/list.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "wpaudio/altypes.h"
+
+#include <cstdint>
+
+using Priority = std::intptr_t;
+
+struct ListNode
+{
+    ListNode* prev = nullptr;
+    ListNode* next = nullptr;
+    Priority pri = 0;
+};
+
+using ListHead = ListNode;
+
+inline bool ListNodeIsHead(const ListNode* node)
+{
+    return node != nullptr && node->pri == reinterpret_cast<Priority>(node);
+}
+
+inline bool ListNodeInList(const ListNode* node)
+{
+    return node != nullptr && (node->next != node || node->prev != node);
+}
+
+void ListInit(ListHead* head);
+void ListNodeInit(ListNode* node);
+int ListAddNodeSortAscending(ListHead* head, ListNode* newNode);
+void ListAddNode(ListHead* head, ListNode* newNode);
+void ListAddNodeAfter(ListHead* head, ListNode* newNode);
+void ListMerge(ListHead* from, ListHead* to);
+int ListCountItems(ListHead* head);
+ListNode* ListFirstItem(ListHead* head);
+ListNode* ListNextItem(ListNode* node);
+ListNode* ListGetItem(ListHead* head, int number);
+void ListNodeInsert(ListNode* node, ListNode* newNode);
+void ListNodeAppend(ListNode* node, ListNode* newNode);
+void ListNodeRemove(ListNode* node);
+ListNode* ListNodeNext(ListNode* node);
+ListNode* ListNodePrev(ListNode* node);
+ListNode* ListNodeLoopNext(ListNode* node);
+ListNode* ListNodeLoopPrev(ListNode* node);
+
+inline void ListAddToTail(ListHead* head, ListNode* node)
+{
+    if (head != nullptr && node != nullptr)
+    {
+        ListNodeInsert(reinterpret_cast<ListNode*>(head), node);
+    }
+}
+

--- a/GeneralsMD/Code/GameEngine/Include/wpaudio/lock.h
+++ b/GeneralsMD/Code/GameEngine/Include/wpaudio/lock.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "wpaudio/altypes.h"
+
+#include <atomic>
+#include <mutex>
+
+struct Lock
+{
+    std::recursive_mutex mutex;
+    std::atomic<int> count{0};
+};
+
+inline void LockInitPrimitive(Lock* lock)
+{
+    if (lock != nullptr)
+    {
+        lock->count.store(0, std::memory_order_relaxed);
+    }
+}
+
+inline void LockAcquirePrimitive(Lock* lock)
+{
+    if (lock != nullptr)
+    {
+        lock->mutex.lock();
+        lock->count.fetch_add(1, std::memory_order_relaxed);
+    }
+}
+
+inline void LockReleasePrimitive(Lock* lock)
+{
+    if (lock != nullptr)
+    {
+        lock->count.fetch_sub(1, std::memory_order_relaxed);
+        lock->mutex.unlock();
+    }
+}
+
+inline bool LockIsLockedPrimitive(const Lock* lock)
+{
+    return lock != nullptr && lock->count.load(std::memory_order_relaxed) > 0;
+}
+
+#define LOCK_INIT(lockPtr) LockInitPrimitive(const_cast<Lock*>(lockPtr))
+#define LOCK_ACQUIRE(lockPtr) LockAcquirePrimitive(const_cast<Lock*>(lockPtr))
+#define LOCK_RELEASE(lockPtr) LockReleasePrimitive(const_cast<Lock*>(lockPtr))
+#define LOCKED(lockPtr) LockIsLockedPrimitive(lockPtr)
+#define NotLocked(lockPtr) (!LockIsLockedPrimitive(lockPtr))
+

--- a/GeneralsMD/Code/GameEngine/Include/wpaudio/memory.h
+++ b/GeneralsMD/Code/GameEngine/Include/wpaudio/memory.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "wpaudio/altypes.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+
+struct MemoryItem
+{
+    MemoryItem* next = nullptr;
+};
+
+struct AudioMemoryPool
+{
+    MemoryItem* next = nullptr;
+    std::size_t itemSize = 0;
+    std::size_t itemCount = 0;
+    std::size_t itemsOut = 0;
+};
+
+inline void* AudioMemAlloc(std::size_t size)
+{
+    return std::malloc(size);
+}
+
+inline void* AudioMemAllocZero(std::size_t size)
+{
+    void* ptr = std::calloc(1u, size);
+    return ptr;
+}
+
+inline void AudioMemFree(void* ptr)
+{
+    std::free(ptr);
+}
+
+inline void AudioMemCopy(void* dst, const void* src, std::size_t size)
+{
+    if (dst != nullptr && src != nullptr)
+    {
+        std::memcpy(dst, src, size);
+    }
+}
+
+inline void AudioMemSet(void* dst, int value, std::size_t size)
+{
+    if (dst != nullptr)
+    {
+        std::memset(dst, value, size);
+    }
+}
+
+template <typename T>
+inline T* AudioMemAllocStruct()
+{
+    return reinterpret_cast<T*>(AudioMemAllocZero(sizeof(T)));
+}
+
+#define ALLOC_STRUCT(var, Type) Type* var = AudioMemAllocStruct<Type>()
+#define MEM_ALLOC_STRUCT(var, Type, flags) ALLOC_STRUCT(var, Type)
+#define MEM_Free(ptr) AudioMemFree(ptr)
+
+AudioMemoryPool* MemoryPoolCreate(std::size_t items, std::size_t size);
+void MemoryPoolDestroy(AudioMemoryPool* pool);
+void* MemoryPoolGetItem(AudioMemoryPool* pool);
+void MemoryPoolReturnItem(AudioMemoryPool* pool, void* data);
+int MemoryPoolCount(AudioMemoryPool* pool);
+
+void AudioAddSlash(char* string);
+int AudioHasPath(const char* string);
+

--- a/GeneralsMD/Code/GameEngine/Include/wpaudio/time.h
+++ b/GeneralsMD/Code/GameEngine/Include/wpaudio/time.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#include "wpaudio/Time.h"
+


### PR DESCRIPTION
## Summary
- introduce portable WPAudio support headers for debugging, memory pools, linked lists, locks, timing, and stream buffering in both Generals and GeneralsMD trees
- update altypes to pull in the new debug utilities and refactor AUD_Memory to use size_t-based pool management with uintptr_t pointer math

## Testing
- `make -j4` *(fails: build still references Win32-specific headers such as <windows.h> in AUD_Windows.cpp and awaits additional cross-platform replacements)*

------
https://chatgpt.com/codex/tasks/task_e_68cf06321c708331bf0bafbe201402db