### PR TITLE
Add case-sensitive include shims and Linux build tweaks

### DIFF
--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/WorldHeightMap.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/WorldHeightMap.h
@@ -36,7 +36,7 @@
 #include "WWLib/RefCount.h"
 #include "WWMath/Vector3.h"
 #include "W3DDevice/GameClient/TileData.h"
-#include "../../gameengine/include/common/MapObject.h"
+#include "GameEngine/Include/Common/MapObject.h"
 
 #include "Common/STLTypedefs.h"
 typedef std::vector<ICoord2D> VecICoord2D;

--- a/Generals/Code/GameEngineDevice/Source/VideoDevice/VLC/VlcVideoPlayer.cpp
+++ b/Generals/Code/GameEngineDevice/Source/VideoDevice/VLC/VlcVideoPlayer.cpp
@@ -42,6 +42,7 @@
 #include <cstdio>
 #include <cstring>
 #include <string>
+#include <climits>
 
 #include <vlc/libvlc_media.h>
 
@@ -78,6 +79,14 @@ inline std::string normalizePath(const char* path)
 }
 }
 
+#ifndef _MAX_PATH
+#ifdef PATH_MAX
+#define _MAX_PATH PATH_MAX
+#else
+#define _MAX_PATH 4096
+#endif
+#endif
+
 //----------------------------------------------------------------------------
 //         VlcVideoStream
 //----------------------------------------------------------------------------
@@ -104,9 +113,15 @@ VlcVideoStream::~VlcVideoStream()
 
 void VlcVideoStream::shutdown()
 {
-        if (m_player && m_player->getAudioBridge())
+        if (m_player)
         {
-                m_player->getAudioBridge()->detach();
+                if (VlcVideoPlayer* vlcPlayer = dynamic_cast<VlcVideoPlayer*>(m_player))
+                {
+                        if (VideoSoundBridge* bridge = vlcPlayer->getAudioBridge())
+                        {
+                                bridge->detach();
+                        }
+                }
         }
 
         std::lock_guard<std::mutex> lock(m_frameMutex);

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/DX8Caps.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/DX8Caps.h
@@ -1,0 +1,5 @@
+#pragma once
+
+// Case-preserving shim for "dx8caps.h".
+
+#include "dx8caps.h"

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/HAnim.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/HAnim.h
@@ -1,0 +1,6 @@
+#pragma once
+
+// Case-preserving shim so code that includes "WW3D2/HAnim.h" resolves on
+// case-sensitive file systems.
+
+#include "hanim.h"

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/Light.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/Light.h
@@ -1,0 +1,6 @@
+#pragma once
+
+// Case-preserving shim so includes of "WW3D2/Light.h" work on case-sensitive
+// file systems.
+
+#include "light.h"

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/Part_Emt.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/Part_Emt.h
@@ -1,0 +1,6 @@
+#pragma once
+
+// Case-preserving shim for "part_emt.h" so includes using "WW3D2/Part_Emt.h"
+// succeed on case-sensitive platforms.
+
+#include "part_emt.h"

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/Render2DSentence.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/Render2DSentence.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// Case-insensitive include compatibility shim.  The original project relied
+// on Windows paths and included this header as "WW3D2/Render2DSentence.h" even
+// though the file on disk is named in lowercase.  Forward the include so the
+// code builds on case-sensitive platforms.
+
+#include "render2dsentence.h"

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/Texture.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/Texture.h
@@ -1,0 +1,6 @@
+#pragma once
+
+// Case-preserving shim for "texture.h" to support builds on case-sensitive
+// platforms.
+
+#include "texture.h"

--- a/Generals/Code/Libraries/Source/WWVegas/WW3D2/WW3DFormat.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WW3D2/WW3DFormat.h
@@ -1,0 +1,9 @@
+#pragma once
+
+// Windows file systems are case-insensitive, but most POSIX platforms are not.
+// The original code base frequently includes this header using the mixed case
+// path "WW3D2/WW3DFormat.h" even though the actual file on disk is named
+// "ww3dformat.h".  Provide a thin wrapper that simply forwards to the real
+// header so builds succeed on case-sensitive file systems.
+
+#include "ww3dformat.h"

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/RefCount.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/RefCount.h
@@ -1,0 +1,7 @@
+#pragma once
+
+// Case-preserving shim for builds on case-sensitive file systems.  The legacy
+// code includes "WWLib/RefCount.h" but the repository stores the file in all
+// lowercase.
+
+#include "refcount.h"

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/random.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/random.h
@@ -1,0 +1,5 @@
+#pragma once
+
+// Case-preserving shim for the legacy "RANDOM.H" header.
+
+#include "RANDOM.H"

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/slist.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/slist.h
@@ -1,0 +1,6 @@
+#pragma once
+
+// Case-preserving shim so includes of "slist.h" resolve to the legacy header
+// stored as "SLIST.H" in the repository.
+
+#include "SLIST.H"

--- a/Generals/Code/Libraries/Source/WWVegas/WWLib/slnode.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWLib/slnode.h
@@ -1,0 +1,6 @@
+#pragma once
+
+// Case-preserving shim for the legacy "SLNODE.H" header on case-sensitive
+// platforms.
+
+#include "SLNODE.H"

--- a/Generals/Code/Libraries/Source/WWVegas/WWMath/Vector3.h
+++ b/Generals/Code/Libraries/Source/WWVegas/WWMath/Vector3.h
@@ -1,0 +1,6 @@
+#pragma once
+
+// Case-preserving shim so code that includes "WWMath/Vector3.h" resolves to
+// the lowercase header on disk when building on case-sensitive platforms.
+
+#include "vector3.h"

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ endif
 # Useful preprocessor definitions similar to the legacy MSVC project
 CPPFLAGS   += -DWIN32 -D_WINDOWS -DNOMINMAX -D_CRT_SECURE_NO_DEPRECATE
 CPPFLAGS   += -DBX_CONFIG_DEBUG=0
-CPPFLAGS   += -DWW3D_BGFX_AVAILABLE=1
+CPPFLAGS   += -DWW3D_BGFX_AVAILABLE=0
 WW3D_ENABLE_LEGACY_DX8 ?= 0
 CPPFLAGS   += -DWW3D_ENABLE_LEGACY_DX8=$(WW3D_ENABLE_LEGACY_DX8)
 
@@ -67,8 +67,11 @@ INCLUDE_DIRS := \
         $(SRC_DIR)/Libraries/Source/WWVegas/WWLib \
         $(SRC_DIR)/Libraries/Source/WWVegas/WWMath \
         $(SRC_DIR)/Libraries/Source/WWVegas/WWDebug \
+        $(SRC_DIR)/Libraries/Source/WWVegas/WW3D2 \
         $(SRC_DIR)/Libraries/Source/WWVegas \
+        $(SRC_DIR)/Libraries/Source/WWVegas/WWSaveLoad \
         $(SRC_DIR)/Libraries/Source/Compression \
+        $(SRC_DIR)/Compat/D3D \
         $(SRC_DIR)/Main \
         $(SRC_DIR)/Main/Include
 


### PR DESCRIPTION
## Summary
- add a POSIX-friendly _MAX_PATH fallback and safer audio bridge teardown in the VLC video player
- expand the makefile include search paths and disable the BGFX requirement for non-BGFX builds
- introduce case-preserving wrapper headers for WW3D/WWLib assets and fix the world height map include path for case-sensitive filesystems

## Testing
- make -j2 *(fails: pending Direct3D compatibility work)*

------
https://chatgpt.com/codex/tasks/task_e_68cf8f5ad064833183045a007a501af4