### PR TITLE
Add Unix osdep shim and expand compatibility layer

### DIFF
--- a/Generals/Code/Compat/Windows/windows_compat.h
+++ b/Generals/Code/Compat/Windows/windows_compat.h
@@ -51,6 +51,7 @@ using HCURSOR = void*;
 using HGDIOBJ = void*;
 using HPEN = void*;
 using HKEY = void*;
+using HGLOBAL = void*;
 using LPVOID = void*;
 using LPCVOID = const void*;
 using LPBYTE = BYTE*;
@@ -64,6 +65,7 @@ using LPCTSTR = const char*;
 using LPBOOL = BOOL*;
 using LPWORD = WORD*;
 using LPDWORD = DWORD*;
+using PUINT = unsigned int*;
 using WPARAM = std::uintptr_t;
 using LPARAM = std::intptr_t;
 using LRESULT = std::intptr_t;
@@ -97,6 +99,46 @@ struct SIZE
 {
     LONG cx;
     LONG cy;
+};
+
+struct FILETIME
+{
+    DWORD dwLowDateTime;
+    DWORD dwHighDateTime;
+};
+
+struct IMAGE_DOS_HEADER
+{
+    WORD e_magic;
+    WORD e_cblp;
+    WORD e_cp;
+    WORD e_crlc;
+    WORD e_cparhdr;
+    WORD e_minalloc;
+    WORD e_maxalloc;
+    WORD e_ss;
+    WORD e_sp;
+    WORD e_csum;
+    WORD e_ip;
+    WORD e_cs;
+    WORD e_lfarlc;
+    WORD e_ovno;
+    WORD e_res[4];
+    WORD e_oemid;
+    WORD e_oeminfo;
+    WORD e_res2[10];
+    LONG e_lfanew;
+};
+
+struct IMAGE_FILE_HEADER
+{
+    WORD Machine;
+    WORD NumberOfSections;
+    DWORD TimeDateStamp;
+    DWORD PointerToSymbolTable;
+    DWORD NumberOfSymbols;
+    WORD SizeOfOptionalHeader;
+    WORD Characteristics;
 };
 
 struct EXCEPTION_RECORD
@@ -141,6 +183,23 @@ inline UINT timeEndPeriod(UINT)
 
 DWORD GetTickCount();
 
+DWORD GetFileAttributesA(LPCSTR fileName);
+BOOL DeleteFileA(LPCSTR fileName);
+
+BOOL GetFileTime(HANDLE file,
+                 FILETIME* creationTime,
+                 FILETIME* lastAccessTime,
+                 FILETIME* lastWriteTime);
+
+DWORD GetFileVersionInfoSizeA(LPCSTR fileName, LPDWORD handle);
+BOOL GetFileVersionInfoA(LPCSTR fileName, DWORD handle, DWORD size, LPVOID data);
+BOOL VerQueryValueA(LPCVOID block, LPCSTR subBlock, LPVOID* buffer, PUINT length);
+
+HGLOBAL GlobalAlloc(UINT flags, SIZE_T bytes);
+LPVOID GlobalLock(HGLOBAL memory);
+BOOL GlobalUnlock(HGLOBAL memory);
+HGLOBAL GlobalFree(HGLOBAL memory);
+
 inline DWORD timeGetTime()
 {
     return GetTickCount();
@@ -166,6 +225,15 @@ constexpr BOOL FALSE_VALUE = 0;
 constexpr DWORD INFINITE = 0xffffffffu;
 constexpr DWORD MAX_PATH = 260;
 constexpr std::size_t _MAX_PATH = 260;
+
+constexpr DWORD FILE_ATTRIBUTE_READONLY = 0x00000001u;
+constexpr DWORD FILE_ATTRIBUTE_DIRECTORY = 0x00000010u;
+constexpr DWORD INVALID_FILE_ATTRIBUTES = 0xffffffffu;
+
+constexpr UINT GMEM_FIXED = 0x0000u;
+constexpr UINT GMEM_MOVEABLE = 0x0002u;
+constexpr UINT GMEM_ZEROINIT = 0x0040u;
+constexpr UINT GHND = GMEM_MOVEABLE | GMEM_ZEROINIT;
 
 constexpr UINT MB_OK = 0x00000000u;
 constexpr UINT MB_OKCANCEL = 0x00000001u;
@@ -447,6 +515,7 @@ using cnc::windows::LPCTSTR;
 using cnc::windows::LPBOOL;
 using cnc::windows::LPWORD;
 using cnc::windows::LPDWORD;
+using cnc::windows::PUINT;
 using cnc::windows::WPARAM;
 using cnc::windows::LPARAM;
 using cnc::windows::LRESULT;
@@ -464,6 +533,9 @@ using cnc::windows::LPCOLESTR;
 using cnc::windows::RECT;
 using cnc::windows::POINT;
 using cnc::windows::SIZE;
+using cnc::windows::FILETIME;
+using cnc::windows::IMAGE_DOS_HEADER;
+using cnc::windows::IMAGE_FILE_HEADER;
 using cnc::windows::EXCEPTION_RECORD;
 using cnc::windows::CONTEXT;
 using cnc::windows::EXCEPTION_POINTERS;
@@ -484,6 +556,9 @@ using cnc::windows::FALSE_VALUE;
 using cnc::windows::INFINITE;
 using cnc::windows::MAX_PATH;
 using cnc::windows::_MAX_PATH;
+using cnc::windows::FILE_ATTRIBUTE_READONLY;
+using cnc::windows::FILE_ATTRIBUTE_DIRECTORY;
+using cnc::windows::INVALID_FILE_ATTRIBUTES;
 using cnc::windows::S_OK;
 using cnc::windows::S_FALSE;
 using cnc::windows::E_FAIL;
@@ -524,6 +599,8 @@ using cnc::windows::timeBeginPeriod;
 using cnc::windows::timeEndPeriod;
 using cnc::windows::timeGetTime;
 using cnc::windows::GetTickCount;
+using cnc::windows::GetFileAttributesA;
+using cnc::windows::DeleteFileA;
 using cnc::windows::ZeroMemory;
 using cnc::windows::CopyMemory;
 using cnc::windows::MoveMemory;
@@ -537,6 +614,14 @@ using cnc::windows::lstrlenA;
 using cnc::windows::OutputDebugStringA;
 using cnc::windows::GetLastError;
 using cnc::windows::SetLastError;
+using cnc::windows::GetFileTime;
+using cnc::windows::GetFileVersionInfoSizeA;
+using cnc::windows::GetFileVersionInfoA;
+using cnc::windows::VerQueryValueA;
+using cnc::windows::GlobalAlloc;
+using cnc::windows::GlobalLock;
+using cnc::windows::GlobalUnlock;
+using cnc::windows::GlobalFree;
 using cnc::windows::ShowWindow;
 using cnc::windows::SetWindowPos;
 using cnc::windows::MessageBoxA;
@@ -569,6 +654,12 @@ using cnc::windows::DebugBreak;
 
 #define MAKELONG(a, b) static_cast<LONG>((static_cast<DWORD>(static_cast<WORD>(a)) & 0xffff) | (static_cast<DWORD>(static_cast<WORD>(b)) << 16))
 #define MAKEWORD(a, b) static_cast<WORD>((static_cast<BYTE>(a) & 0xff) | ((static_cast<WORD>(static_cast<BYTE>(b)) & 0xff) << 8))
+
+#define GetFileAttributes GetFileAttributesA
+#define DeleteFile DeleteFileA
+#define GetFileVersionInfoSize GetFileVersionInfoSizeA
+#define GetFileVersionInfo GetFileVersionInfoA
+#define VerQueryValue VerQueryValueA
 
 #endif // !_WIN32
 

--- a/Generals/Code/compat/string_compat.h
+++ b/Generals/Code/compat/string_compat.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #ifndef _WIN32
+#include <cctype>
 #include <cstddef>
 #include <strings.h>
 #include <wchar.h>
@@ -11,5 +12,23 @@ inline int _wcsicmp(const wchar_t* lhs, const wchar_t* rhs) { return wcscasecmp(
 inline int _wcsnicmp(const wchar_t* lhs, const wchar_t* rhs, size_t count) { return wcsncasecmp(lhs, rhs, count); }
 inline int stricmp(const char* lhs, const char* rhs) { return _stricmp(lhs, rhs); }
 inline int strnicmp(const char* lhs, const char* rhs, size_t count) { return _strnicmp(lhs, rhs, count); }
+inline char* strupr(char* value)
+{
+    if (value == nullptr)
+    {
+        return nullptr;
+    }
+
+    for (char* cursor = value; *cursor != '\0'; ++cursor)
+    {
+        *cursor = static_cast<char>(std::toupper(static_cast<unsigned char>(*cursor)));
+    }
+    return value;
+}
+
+inline char* _strupr(char* value)
+{
+    return strupr(value);
+}
 #endif  // _WIN32
 

--- a/Generals/Code/osdep.h
+++ b/Generals/Code/osdep.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#include "osdep/osdep.h"
+

--- a/Generals/Code/osdep/osdep.h
+++ b/Generals/Code/osdep/osdep.h
@@ -1,0 +1,51 @@
+#pragma once
+
+// Platform abstraction helpers used throughout the original codebase.
+// The legacy projects relied on a Windows-only "osdep" layer to collect
+// commonly used Win32 headers and keywords.  For the Unix oriented build we
+// provide lightweight shims that map the expected Windows types and calling
+// conventions onto the portable compatibility headers that already exist in
+// the modernised codebase.
+
+#if defined(_WIN32)
+
+// The Windows toolchain still uses the original header layout.
+#include <windows.h>
+
+#else
+
+#include "compat/win_compat.h"
+
+// The compatibility header already re-exports most Win32 types and helpers,
+// but a few MSVC specific keywords occasionally leak through in the older
+// source files.  Define them away so that clang/gcc can accept the code.
+#ifndef __forceinline
+#define __forceinline inline
+#endif
+
+#ifndef __declspec
+#define __declspec(_x)
+#endif
+
+#ifndef __fastcall
+#define __fastcall
+#endif
+
+#ifndef __stdcall
+#define __stdcall
+#endif
+
+#ifndef __declspec_novtable
+#define __declspec_novtable
+#endif
+
+#ifndef MAX_PATH
+#define MAX_PATH 260
+#endif
+
+#ifndef _MAX_PATH
+#define _MAX_PATH 260
+#endif
+
+#endif // platform check
+


### PR DESCRIPTION
## Summary
- add a lightweight osdep shim that forwards to the existing compatibility layer on non-Windows builds
- extend the string compatibility helpers with strupr implementations
- expand the Windows compatibility header and runtime stubs so Linux builds can resolve file attributes, FILETIME, and GlobalAlloc APIs

## Testing
- make -j4 *(fails: build still requires additional Windows-specific headers such as download.h and D3D surface definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68d56227524c8331a36703c349d449c9