### PR TITLE
Fix W3DDynamicLight BaseType include path case

### DIFF
--- a/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDynamicLight.h
+++ b/Generals/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDynamicLight.h
@@ -32,7 +32,7 @@
 #define W3D_DYNAMIC_LIGHT_H
 
 #include "WW3D2/Light.h"
-#include "lib/baseType.h"
+#include "Lib/BaseType.h"
 class HeightMapRenderObjClass;
 
 /*************************************************************************

--- a/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDynamicLight.h
+++ b/GeneralsMD/Code/GameEngineDevice/Include/W3DDevice/GameClient/W3DDynamicLight.h
@@ -32,7 +32,7 @@
 #define W3D_DYNAMIC_LIGHT_H
 
 #include "WW3D2/Light.h"
-#include "lib/baseType.h"
+#include "Lib/BaseType.h"
 class HeightMapRenderObjClass;
 
 /*************************************************************************


### PR DESCRIPTION
## Summary
- point W3DDynamicLight to the correct BaseType header path in both Generals and GeneralsMD trees

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7850581a88331b164c68c3cf4c3fc